### PR TITLE
Bug fixes and late game added

### DIFF
--- a/FFXCutsceneRemover/Components/CutsceneRemover.cs
+++ b/FFXCutsceneRemover/Components/CutsceneRemover.cs
@@ -133,7 +133,8 @@ namespace FFXCutsceneRemover
                     if (new GameState { RoomNumber = 138, Storyline = 1720, State = 1}.CheckState() && MemoryWatchers.Sandragoras.Current >= 4)
                     {
                         Game.Suspend();
-                        new Transition { RoomNumber = 130, Storyline = 1800, SpawnPoint = 0, Description = "Sanubia to Home"};
+                        new Transition { RoomNumber = 130, Storyline = 1800, SpawnPoint = 0 }.Execute();
+                        Console.WriteLine("Sanubia to Home (Custom skip)");
                         Game.Resume();
                     }
                     
@@ -141,7 +142,8 @@ namespace FFXCutsceneRemover
                     if (new GameState { RoomNumber = 194, Storyline = 2000, State = 0}.CheckState() && MemoryWatchers.XCoordinate.Current > 300f)
                     {
                         Game.Suspend();
-                        new Transition { RoomNumber = 194, Storyline = 2020, SpawnPoint = 1, Description = "Zoom in on Bevelle"};
+                        new Transition { RoomNumber = 194, Storyline = 2020, SpawnPoint = 1 }.Execute();
+                        Console.WriteLine("Zoom in on Bevelle (Custom skip)");
                         Game.Resume();
                     }
                     
@@ -149,7 +151,8 @@ namespace FFXCutsceneRemover
                     if (new GameState { RoomNumber = 279, Storyline = 2420, MovementLock = 48}.CheckState() && MemoryWatchers.XCoordinate.Current > 250f)
                     {
                         Game.Suspend();
-                        new Transition { RoomNumber = 259, Storyline = 2510, SpawnPoint = 0, Description = "Yuna looks at Defender X's corpse"};
+                        new Transition { RoomNumber = 259, Storyline = 2510, SpawnPoint = 0 }.Execute();
+                        Console.WriteLine("Yuna looks at Defender X's corpse (Custom skip)");
                         Game.Resume();
                     }
 

--- a/FFXCutsceneRemover/Components/CutsceneRemover.cs
+++ b/FFXCutsceneRemover/Components/CutsceneRemover.cs
@@ -153,6 +153,7 @@ namespace FFXCutsceneRemover
                         Game.Suspend();
                         new Transition { RoomNumber = 259, Storyline = 2510, SpawnPoint = 0 }.Execute();
                         Console.WriteLine("Yuna looks at Defender X's corpse (Custom skip)");
+                        // Bug: If you enter sunken cave and return to this screen, you will skip to Gagazet (issue with using coords - need to find another method)
                         Game.Resume();
                     }
 

--- a/FFXCutsceneRemover/Components/CutsceneRemover.cs
+++ b/FFXCutsceneRemover/Components/CutsceneRemover.cs
@@ -93,7 +93,7 @@ namespace FFXCutsceneRemover
                             {
                                 InBossFight = true;
                                 PostBossFightTransition = transition.Value;
-                                Console.WriteLine("Entered Boss Fight");
+                                Console.WriteLine("Entered Boss Fight: " + transition.Value.Description);
                             }
                         }
                     }
@@ -141,7 +141,7 @@ namespace FFXCutsceneRemover
                     if (new GameState { RoomNumber = 194, Storyline = 2000, State = 0}.CheckState() && MemoryWatchers.XCoordinate.Current > 300f)
                     {
                         Game.Suspend();
-                        new Transition {RoomNumber = 194, Storyline = 2020, SpawnPoint = 1, Description = "Zoom in on Bevelle"};
+                        new Transition { RoomNumber = 194, Storyline = 2020, SpawnPoint = 1, Description = "Zoom in on Bevelle"};
                         Game.Resume();
                     }
                     
@@ -149,7 +149,7 @@ namespace FFXCutsceneRemover
                     if (new GameState { RoomNumber = 279, Storyline = 2420, MovementLock = 48}.CheckState() && MemoryWatchers.XCoordinate.Current > 250f)
                     {
                         Game.Suspend();
-                        new Transition {RoomNumber = 259, Storyline = 2510, SpawnPoint = 0, Description = "Yuna looks at Defender X's corpse"};
+                        new Transition { RoomNumber = 259, Storyline = 2510, SpawnPoint = 0, Description = "Yuna looks at Defender X's corpse"};
                         Game.Resume();
                     }
 

--- a/FFXCutsceneRemover/Components/GameState.cs
+++ b/FFXCutsceneRemover/Components/GameState.cs
@@ -27,7 +27,7 @@ namespace FFXCutsceneRemover
         public byte? MovementLock = null;
         public byte? MusicId = null;
         public byte? CutsceneAlt = null;
-        public byte? AirshipDestinations = null;
+        public short? AirshipDestinations = null;
         public short? AuronOverdrives = null;
         public byte? PartyMembers = null;
         public byte? Sandragoras = null;

--- a/FFXCutsceneRemover/Components/MemoryWatchers.cs
+++ b/FFXCutsceneRemover/Components/MemoryWatchers.cs
@@ -68,7 +68,7 @@ namespace FFXCutsceneRemover
         public MemoryWatcher<byte> MacalaniaFlag;
 
         public MemoryWatcher<byte> Formation;
-        public MemoryWatcher<byte> ViaPurifico;
+        public MemoryWatcher<byte> ViaPurificoPlatform;
 
         MemoryWatchers() { }
 
@@ -141,7 +141,7 @@ namespace FFXCutsceneRemover
             MacalaniaFlag = GetMemoryWatcher<byte>(MemoryLocations.MacalaniaFlag);
 
             Formation = GetMemoryWatcher<byte>(MemoryLocations.Formation);
-            ViaPurifico = GetMemoryWatcher<byte>(MemoryLocations.ViaPurifico);
+            ViaPurificoPlatform = GetMemoryWatcher<byte>(MemoryLocations.ViaPurificoPlatform);
 
             Watchers.Clear();
             Watchers.AddRange(new List<MemoryWatcher>() { 
@@ -186,7 +186,7 @@ namespace FFXCutsceneRemover
                     MoonflowFlag2,
                     RikkuOutfit,
                     MacalaniaFlag,
-                    ViaPurifico
+                    ViaPurificoPlatform
             });
         }
 

--- a/FFXCutsceneRemover/Components/MemoryWatchers.cs
+++ b/FFXCutsceneRemover/Components/MemoryWatchers.cs
@@ -38,7 +38,7 @@ namespace FFXCutsceneRemover
         public MemoryWatcher<byte> MovementLock;
         public MemoryWatcher<byte> MusicId;
         public MemoryWatcher<byte> CutsceneAlt;
-        public MemoryWatcher<byte> AirshipDestinations;
+        public MemoryWatcher<short> AirshipDestinations;
         public MemoryWatcher<short> AuronOverdrives;
         public MemoryWatcher<byte> PartyMembers;
         public MemoryWatcher<byte> Sandragoras;
@@ -68,7 +68,10 @@ namespace FFXCutsceneRemover
         public MemoryWatcher<byte> MacalaniaFlag;
 
         public MemoryWatcher<byte> Formation;
+        
         public MemoryWatcher<byte> ViaPurificoPlatform;
+        
+        public MemoryWatcher<byte> CalmLandsFlag;
 
         MemoryWatchers() { }
 
@@ -111,7 +114,7 @@ namespace FFXCutsceneRemover
             MovementLock = GetMemoryWatcher<byte>(MemoryLocations.MovementLock);
             MusicId = GetMemoryWatcher<byte>(MemoryLocations.MusicId);
             CutsceneAlt = GetMemoryWatcher<byte>(MemoryLocations.CutsceneAlt);
-            AirshipDestinations = GetMemoryWatcher<byte>(MemoryLocations.AirshipDestinations);
+            AirshipDestinations = GetMemoryWatcher<short>(MemoryLocations.AirshipDestinations);
             AuronOverdrives = GetMemoryWatcher<short>(MemoryLocations.AuronOverdrives);
             PartyMembers = GetMemoryWatcher<byte>(MemoryLocations.PartyMembers);
             Sandragoras = GetMemoryWatcher<byte>(MemoryLocations.Sandragoras);
@@ -142,6 +145,7 @@ namespace FFXCutsceneRemover
 
             Formation = GetMemoryWatcher<byte>(MemoryLocations.Formation);
             ViaPurificoPlatform = GetMemoryWatcher<byte>(MemoryLocations.ViaPurificoPlatform);
+            CalmLandsFlag = GetMemoryWatcher<byte>(MemoryLocations.CalmLandsFlag);
 
             Watchers.Clear();
             Watchers.AddRange(new List<MemoryWatcher>() { 
@@ -186,7 +190,8 @@ namespace FFXCutsceneRemover
                     MoonflowFlag2,
                     RikkuOutfit,
                     MacalaniaFlag,
-                    ViaPurificoPlatform
+                    ViaPurificoPlatform,
+                    CalmLandsFlag
             });
         }
 

--- a/FFXCutsceneRemover/Components/Transition.cs
+++ b/FFXCutsceneRemover/Components/Transition.cs
@@ -32,7 +32,7 @@ namespace FFXCutsceneRemover
         public byte? MovementLock = null;
         public byte? MusicId = null;
         public byte? CutsceneAlt = null;
-        public byte? AirshipDestinations = null;
+        public short? AirshipDestinations = null;
         public short? AuronOverdrives = null;
         public byte? PartyMembers = null;
         public byte? Sandragoras = null;
@@ -64,6 +64,7 @@ namespace FFXCutsceneRemover
         public byte[] Formation = null;
         
         public byte? ViaPurificoPlatform = null;
+        public byte? CalmLandsFlag = null;
 
         public void Execute()
         {
@@ -111,6 +112,7 @@ namespace FFXCutsceneRemover
             WriteValue(memoryWatchers.MacalaniaFlag, MacalaniaFlag);
             WriteBytes(memoryWatchers.Formation, Formation);
             WriteValue(memoryWatchers.ViaPurificoPlatform, ViaPurificoPlatform);
+            WriteValue(memoryWatchers.CalmLandsFlag, CalmLandsFlag);
 
             if (ForceLoad)
             {

--- a/FFXCutsceneRemover/Components/Transition.cs
+++ b/FFXCutsceneRemover/Components/Transition.cs
@@ -63,7 +63,7 @@ namespace FFXCutsceneRemover
 
         public byte[] Formation = null;
         
-        public byte? ViaPurifico = null;
+        public byte? ViaPurificoPlatform = null;
 
         public void Execute()
         {
@@ -110,7 +110,7 @@ namespace FFXCutsceneRemover
             WriteValue(memoryWatchers.RikkuOutfit, RikkuOutfit);
             WriteValue(memoryWatchers.MacalaniaFlag, MacalaniaFlag);
             WriteBytes(memoryWatchers.Formation, Formation);
-            WriteValue(memoryWatchers.ViaPurifico, ViaPurifico);
+            WriteValue(memoryWatchers.ViaPurificoPlatform, ViaPurificoPlatform);
 
             if (ForceLoad)
             {

--- a/FFXCutsceneRemover/Resources/MemoryLocationNames.cs
+++ b/FFXCutsceneRemover/Resources/MemoryLocationNames.cs
@@ -53,6 +53,6 @@
 
         public static string Formation = "Formation";
 
-        public static string ViaPurifico = "ViaPurifico";
+        public static string ViaPurificoPlatform = "ViaPurificoPlatform";
     }
 }

--- a/FFXCutsceneRemover/Resources/MemoryLocationNames.cs
+++ b/FFXCutsceneRemover/Resources/MemoryLocationNames.cs
@@ -54,5 +54,6 @@
         public static string Formation = "Formation";
 
         public static string ViaPurificoPlatform = "ViaPurificoPlatform";
+        public static string CalmLandsFlag = "CalmLandsFlag";
     }
 }

--- a/FFXCutsceneRemover/Resources/MemoryLocations.cs
+++ b/FFXCutsceneRemover/Resources/MemoryLocations.cs
@@ -60,7 +60,7 @@
 
         public static MemoryLocationData Formation = new MemoryLocationData(MemoryLocationNames.Formation, 0xD307E8);
         
-        public static MemoryLocationData ViaPurifico = new MemoryLocationData(MemoryLocationNames.ViaPurifico, 0xD2CC84);
+        public static MemoryLocationData ViaPurificoPlatform = new MemoryLocationData(MemoryLocationNames.ViaPurificoPlatform, 0xD2CC84);
     }
 
     public struct MemoryLocationData

--- a/FFXCutsceneRemover/Resources/MemoryLocations.cs
+++ b/FFXCutsceneRemover/Resources/MemoryLocations.cs
@@ -61,6 +61,9 @@
         public static MemoryLocationData Formation = new MemoryLocationData(MemoryLocationNames.Formation, 0xD307E8);
         
         public static MemoryLocationData ViaPurificoPlatform = new MemoryLocationData(MemoryLocationNames.ViaPurificoPlatform, 0xD2CC84);
+        public static MemoryLocationData CalmLandsFlag = new MemoryLocationData(MemoryLocationNames.CalmLandsFlag, 0xD2CD09);
+        
+        
     }
 
     public struct MemoryLocationData

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -308,8 +308,31 @@ namespace FFXCutsceneRemover.Resources
 		    } },
 		    { new GameState { RoomNumber = 183, Storyline = 2290}, new Transition { RoomNumber = 183, Storyline = 2300, SpawnPoint = 0, ForceLoad = false, Description = "Natus Death"} },
 		    // END OF BEVELLE
-		    // START OF CALM LANDS
+		    // START OF CALM LANDS & GAGAZET
 		    { new GameState { RoomNumber = 206, Storyline = 2300, CutsceneAlt = 128}, new Transition { RoomNumber = 177, Storyline = 2385, SpawnPoint = 1, Description = "Lake Scene"} },
+		    { new GameState { RoomNumber = 223, Storyline = 2385}, new Transition { Storyline = 2400, CalmLandsFlag = 36, ForceLoad = false, Description = "Calm Lands Intro + Gorge flag"} },
+		    { new GameState { RoomNumber = 259, Storyline = 2510, CutsceneAlt = 70}, new Transition { Storyline = 2530, SpawnPoint = 1, Description = "Ronso Singing"} },
+		    // TODO: Add back in the flashback
+		    //{ new GameState { RoomNumber = 285, Storyline = 2555 }, new Transition { Storyline = 2585, SpawnPoint = 2, Description = "Flux to Sanctuary Keeper"} },
+		    // TODO: Auron talks to Yuna at the end of the cave
+		    // END OF GAGAZET
+		    // START OF ZANARKAND
+		    { new GameState { RoomNumber = 132, Storyline =  2680, State = 0}, new Transition { RoomNumber = 363, Storyline = 2767, SpawnPoint = 0, Description = "Zanarkand Campfire"} },
+		    { new GameState { RoomNumber = 318, Storyline = 2790}, new Transition { Storyline = 2815, Description = "Spectral Keeper to Yunalesca"} },
+		    { new GameState { RoomNumber = 270, Storyline = 2835 }, new Transition { Storyline = 2850, ForceLoad = false, Description = "Auron flashback"} },
+		    { new GameState { RoomNumber = 315, Storyline = 2850 }, new Transition { RoomNumber = 194, Storyline = 2900, SpawnPoint = 2, Description = "End of Zanarkand"} },
+		    // END OF ZANARKAND
+		    // START OF SIN
+		    { new GameState { RoomNumber = 211, Storyline = 2900, XCoordinate = -9.918679f}, new Transition { Storyline = 2915, SpawnPoint = 7, AirshipDestinations = 2048, Description = "Yuna/Kimahri talk about defeating Sin"} },
+		    { new GameState { RoomNumber = 208, Storyline = 2920, CutsceneAlt = 90}, new Transition { RoomNumber = 255, Storyline = 2970, SpawnPoint = 0, AirshipDestinations = 2560, Description = "Return from Highbridge"} },
+		    { new GameState { RoomNumber = 255, Storyline = 2990}, new Transition { RoomNumber = 211, Storyline = 3010, SpawnPoint = 1, Description = "Sin destination cutscene"} }, //Bug (Minor): Wrong area/spawn
+		    { new GameState { RoomNumber = 277, Storyline = 3010}, new Transition { RoomNumber = 199, Storyline = 3085, Description = "Left Fin" } },
+		    { new GameState { RoomNumber = 200, Storyline = 3100}, new Transition { RoomNumber = 201, Storyline = 3105, Description = "Right Fin death" } },
+		    { new GameState { RoomNumber = 201, Storyline = 3120}, new Transition { RoomNumber = 374, Storyline = 3125, SpawnPoint = 1, ForceLoad = false, Description = "Core Death"} },
+		    { new GameState { RoomNumber = 202, Storyline = 3125, XCoordinate = 18.58586121f, State = 0}, new Transition { RoomNumber = 374, Storyline = 3135, SpawnPoint = 1, Description = "Yuna monologue"} },
+		    { new GameState { RoomNumber = 204, Storyline = 3210}, new Transition { Storyline = 3250, ForceLoad = false, Description = "Nucleus spawned"} },
+		    { new GameState { RoomNumber = 325, Storyline = 3300, CutsceneAlt = 71}, new Transition { RoomNumber = 326, Storyline = 3360, Description = "BFA Death. GG!"} }
+		    
         };
 
         public static readonly Dictionary<IGameState, Transition> PostBossBattleTransitions = new Dictionary<IGameState, Transition>()
@@ -321,7 +344,9 @@ namespace FFXCutsceneRemover.Resources
 	            Formation = new byte[]{ 0x0, 0x2, 0x5, 0x4, 0xFF, 0xFF, 0xFF }, EnableWakka = 17} },
             { new GameState { HpEnemyA = 9000, Storyline = 1885 }, new Transition { RoomNumber = 280, Storyline = 1940, SpawnPoint = 4, Description = "Home Chimera"} },
             { new GameState { HpEnemyA = 70000, Storyline = 2555 }, new Transition { RoomNumber = 285, Storyline = 2585, SpawnPoint = 2, Description = "Seymour Flux"} },
-            { new GameState { HpEnemyA = 40000, Storyline = 2585 }, new Transition { RoomNumber = 311, Storyline = 2680, SpawnPoint = 0, Description = "Sanctuary Keeper"} },
+            { new GameState { HpEnemyA = 40000, Storyline = 2585 }, new Transition { RoomNumber = 311, Storyline = 2680, SpawnPoint = 0, Description = "Sanctuary Keeper"} }
+            // TODO: Yunalesca
+            
 	            
         };
     }

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -279,23 +279,16 @@ namespace FFXCutsceneRemover.Resources
 			    Formation = new byte[]{ 0x0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
 			    EnableTidus = 17, EnableYuna = 0, EnableAuron = 0, EnableKimahri = 0, EnableWakka = 0, EnableLulu = 0, EnableRikku = 0
 		    } },
-		    { new GameState { Storyline = 1715, EnableWakka = 255 }, new Transition
-		    {
-			    RoomNumber = 263, Storyline = 1418, SpawnPoint = 0, ForceLoad = false, Description = "Add Auron, Lulu, Wakka after Zu",
-			    Formation = new byte[]{ 0x0, 0x2, 0x5, 0x4, 0xFF, 0xFF, 0xFF },
-			    EnableAuron = 17, EnableLulu = 17, EnableWakka = 17
-		    } },
 		    { new GameState { RoomNumber = 136, Storyline = 1718, EnableRikku = 255, State = 1 }, new Transition
 			{
-				Storyline = 1720, SpawnPoint = 3, EnableRikku = 17,
+				Storyline = 1720, SpawnPoint = 3, EnableRikku = 17, Description = "Wakka Glare",
 				Formation = new byte[]{ 0x0, 0x2, 0x5, 0x4, 0x6, 0xFF, 0xFF }
-				
 			} },
 		    { new GameState { Storyline = 1940, EncounterStatus = 89 }, new Transition { EncounterStatus = 88, ForceLoad = false, Description = "Disabling Encounters"} },
-		    { new GameState { RoomNumber = 261, Storyline = 1940 }, new Transition { RoomNumber = 194, Storyline = 1950, SpawnPoint = 1, ForceLoad = false, Description = "Home to Airship"} },
+		    { new GameState { RoomNumber = 261, Storyline = 1940 }, new Transition { RoomNumber = 194, Storyline = 1950, SpawnPoint = 1, Description = "Home to Airship"} },
 		    { new GameState { RoomNumber = 194, Storyline = 1990 }, new Transition { Storyline = 2000, SpawnPoint = 1, ForceLoad = false, Description = "Airship Bridge Cutscene"} },
 		    { new GameState { RoomNumber = 351, Storyline = 2020 }, new Transition { Storyline = 2040, ForceLoad = false, Description = "Red carpet has teeth"} },
-		    
+		    // END OF HOME
 		    // START OF BEVELLE
 		    { new GameState { RoomNumber = 205, Storyline = 2060, State = 1}, new Transition { Storyline = 2075, SpawnPoint = 0, Description = "Evrae to Guards"} },
 		    { new GameState { RoomNumber = 205, Storyline = 2085}, new Transition { RoomNumber = 180, Storyline = 2135, Description = "Bevelle Guards to Trials"} },
@@ -307,8 +300,10 @@ namespace FFXCutsceneRemover.Resources
 			    EnableTidus = 0, EnableYuna = 17, EnableAuron = 0, EnableKimahri = 0, EnableWakka = 0, EnableLulu = 0, EnableRikku = 0,
 			    ViaPurificoPlatform = 1 //Bug (Minor): Doesn't seem to be working on ASL either. Value should enable the first platform and set direction to North
 		    } },
-		    { new GameState { RoomNumber = 208, Storyline = 2220}, new Transition { RoomNumber = 208, Storyline = 2275, SpawnPoint = 2, ForceLoad = false, Description = "Enter Highbridge"} },
+		    { new GameState { RoomNumber = 208, Storyline = 2220}, new Transition { Storyline = 2275, SpawnPoint = 2, ForceLoad = false, Description = "Enter Highbridge"} },
 		    { new GameState { RoomNumber = 183, Storyline = 2290}, new Transition { RoomNumber = 183, Storyline = 2300, SpawnPoint = 0, ForceLoad = false, Description = "Natus Death"} },
+		    // END OF BEVELLE
+		    // START OF CALM LANDS
 		    { new GameState { RoomNumber = 206, Storyline = 2300, CutsceneAlt = 128}, new Transition { RoomNumber = 177, Storyline = 2385, SpawnPoint = 1, Description = "Lake Scene"} },
         };
 
@@ -317,7 +312,8 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { HpEnemyA = 12000, Storyline = 1420 }, new Transition { RoomNumber = 221, Storyline = 1480, SpawnPoint = 2, Description = "Spherimorph", AuronOverdrives = 11569} },
             { new GameState { HpEnemyA = 16000, Storyline = 1485 }, new Transition { RoomNumber = 192, Storyline = 1504, SpawnPoint = 1, Description = "Crawler"} },
             { new GameState { HpEnemyA = 1200, Storyline = 1570 }, new Transition { RoomNumber = 54, Storyline = 1600, SpawnPoint = 0, Description = "Wendigo"} }, // HP Value is the Guard
-            { new GameState { HpEnemyA = 12000, Storyline = 1704 }, new Transition { RoomNumber = 129, Storyline = 1715, SpawnPoint = 0, Description = "Bikanel Zu"} },
+            { new GameState { HpEnemyA = 12000, Storyline = 1704 }, new Transition { RoomNumber = 129, Storyline = 1715, SpawnPoint = 0, Description = "Bikanel Zu",
+	            Formation = new byte[]{ 0x0, 0x2, 0x5, 0x4, 0xFF, 0xFF, 0xFF }, EnableWakka = 17} },
             { new GameState { HpEnemyA = 9000, Storyline = 1885 }, new Transition { RoomNumber = 280, Storyline = 1940, SpawnPoint = 4, Description = "Home Chimera"} },
             { new GameState { HpEnemyA = 70000, Storyline = 2555 }, new Transition { RoomNumber = 285, Storyline = 2585, SpawnPoint = 2, Description = "Seymour Flux"} },
             { new GameState { HpEnemyA = 40000, Storyline = 2585 }, new Transition { RoomNumber = 311, Storyline = 2680, SpawnPoint = 0, Description = "Sanctuary Keeper"} },

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -277,21 +277,21 @@ namespace FFXCutsceneRemover.Resources
 		    {
 			    RoomNumber = 129, Storyline = 1704, SpawnPoint = 0, Description = "Bikanel Intro",
 			    Formation = new byte[]{ 0x0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
-			    EnableTidus = 11, EnableYuna = 0, EnableAuron = 0, EnableKimahri = 0, EnableWakka = 0, EnableLulu = 0, EnableRikku = 0
+			    EnableTidus = 17, EnableYuna = 0, EnableAuron = 0, EnableKimahri = 0, EnableWakka = 0, EnableLulu = 0, EnableRikku = 0
 		    } },
 		    { new GameState { Storyline = 1715, EnableWakka = 255 }, new Transition
 		    {
 			    RoomNumber = 263, Storyline = 1418, SpawnPoint = 0, ForceLoad = false, Description = "Add Auron, Lulu, Wakka after Zu",
 			    Formation = new byte[]{ 0x0, 0x2, 0x5, 0x4, 0xFF, 0xFF, 0xFF },
-			    EnableAuron = 11, EnableLulu = 11, EnableWakka = 11
+			    EnableAuron = 17, EnableLulu = 17, EnableWakka = 17
 		    } },
 		    { new GameState { RoomNumber = 136, Storyline = 1718, EnableRikku = 255, State = 1 }, new Transition
 			{
-				Storyline = 1720, SpawnPoint = 3, EnableRikku = 11,
+				Storyline = 1720, SpawnPoint = 3, EnableRikku = 17,
 				Formation = new byte[]{ 0x0, 0x2, 0x5, 0x4, 0x6, 0xFF, 0xFF }
 				
 			} },
-		    { new GameState { Storyline = 1940, EncounterStatus = 89 }, new Transition { EncounterStatus = 88, Description = "Disabling Encounters"} },
+		    { new GameState { Storyline = 1940, EncounterStatus = 89 }, new Transition { EncounterStatus = 88, ForceLoad = false, Description = "Disabling Encounters"} },
 		    { new GameState { RoomNumber = 261, Storyline = 1940 }, new Transition { RoomNumber = 194, Storyline = 1950, SpawnPoint = 1, ForceLoad = false, Description = "Home to Airship"} },
 		    { new GameState { RoomNumber = 194, Storyline = 1990 }, new Transition { Storyline = 2000, SpawnPoint = 1, ForceLoad = false, Description = "Airship Bridge Cutscene"} },
 		    { new GameState { RoomNumber = 351, Storyline = 2020 }, new Transition { Storyline = 2040, ForceLoad = false, Description = "Red carpet has teeth"} },
@@ -299,13 +299,13 @@ namespace FFXCutsceneRemover.Resources
 		    // START OF BEVELLE
 		    { new GameState { RoomNumber = 205, Storyline = 2060, State = 1}, new Transition { Storyline = 2075, SpawnPoint = 0, Description = "Evrae to Guards"} },
 		    { new GameState { RoomNumber = 205, Storyline = 2085}, new Transition { RoomNumber = 180, Storyline = 2135, Description = "Bevelle Guards to Trials"} },
-		    { new GameState { RoomNumber = 306, Storyline = 2135, State = 1}, new Transition {RoomNumber = 226, Storyline = 2150, ForceLoad = false, Description = "Trials to Bahamut naming"} }, // TODO: Remove this and skip straight to Via Purifico. Add Bahamut manually
+		    { new GameState { RoomNumber = 306, Storyline = 2135}, new Transition { RoomNumber = 226, Storyline = 2150, ForceLoad = false, Description = "Trials to Bahamut naming"} }, // TODO: Remove this and skip straight to Via Purifico. Add Bahamut manually
 		    { new GameState { RoomNumber = 226, Storyline = 2155, Menu = 0}, new Transition
 		    {
 			    RoomNumber = 198, Storyline = 2220, SpawnPoint = 0, Description = "Bahamut to Via Purifico",
 			    Formation = new byte[]{ 0x1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
-			    EnableTidus = 0, EnableYuna = 11, EnableAuron = 0, EnableKimahri = 0, EnableWakka = 0, EnableLulu = 0, EnableRikku = 0,
-			    ViaPurifico = 1 //Bug (Minor): Doesn't seem to be working on ASL either. Value should enable the first platform and set direction to North
+			    EnableTidus = 0, EnableYuna = 17, EnableAuron = 0, EnableKimahri = 0, EnableWakka = 0, EnableLulu = 0, EnableRikku = 0,
+			    ViaPurificoPlatform = 1 //Bug (Minor): Doesn't seem to be working on ASL either. Value should enable the first platform and set direction to North
 		    } },
 		    { new GameState { RoomNumber = 208, Storyline = 2220}, new Transition { RoomNumber = 208, Storyline = 2275, SpawnPoint = 2, ForceLoad = false, Description = "Enter Highbridge"} },
 		    { new GameState { RoomNumber = 183, Storyline = 2290}, new Transition { RoomNumber = 183, Storyline = 2300, SpawnPoint = 0, ForceLoad = false, Description = "Natus Death"} },

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -300,7 +300,12 @@ namespace FFXCutsceneRemover.Resources
 			    EnableTidus = 0, EnableYuna = 17, EnableAuron = 0, EnableKimahri = 0, EnableWakka = 0, EnableLulu = 0, EnableRikku = 0,
 			    ViaPurificoPlatform = 1 //Bug (Minor): Doesn't seem to be working on ASL either. Value should enable the first platform and set direction to North
 		    } },
-		    { new GameState { RoomNumber = 208, Storyline = 2220}, new Transition { Storyline = 2275, SpawnPoint = 2, ForceLoad = false, Description = "Enter Highbridge"} },
+		    { new GameState { RoomNumber = 208, Storyline = 2220}, new Transition
+		    {
+			    Storyline = 2275, SpawnPoint = 2, ForceLoad = true, Description = "Enter Highbridge",
+			    Formation = new byte[]{ 0x0, 0x1, 0x4, 0x6, 0x2, 0x5, 0xFF },
+			    EnableLulu = 17, EnableYuna = 17, EnableAuron = 17
+		    } },
 		    { new GameState { RoomNumber = 183, Storyline = 2290}, new Transition { RoomNumber = 183, Storyline = 2300, SpawnPoint = 0, ForceLoad = false, Description = "Natus Death"} },
 		    // END OF BEVELLE
 		    // START OF CALM LANDS


### PR DESCRIPTION
Fixed bugs:
- wakka is not in the party in bikanel
- the "Disabling Encounters" skip keeps getting triggered, reloading over and over
- the "Bahamut to Via Purifico" skip makes the game crash when trying to move yuna in the sphere grid
- the "Enter Highbridge" skip doesnt add back party members and has the wrong spawnpoint

Also added end game:
Calm lands to Credits