### PR TITLE
Cereth

### DIFF
--- a/FFXCutsceneRemover/Components/GameState.cs
+++ b/FFXCutsceneRemover/Components/GameState.cs
@@ -27,6 +27,7 @@ namespace FFXCutsceneRemover
         public byte? EncounterStatus = null;
         public byte? MovementLock = null;
         public byte? MusicId = null;
+        public short? RoomNumberAlt = null;
         public short? CutsceneAlt = null;
         public short? AirshipDestinations = null;
         public short? AuronOverdrives = null;
@@ -71,6 +72,7 @@ namespace FFXCutsceneRemover
                 TestValue(EncounterStatus, memoryWatchers.EncounterStatus.Current) &&
                 TestValue(MovementLock, memoryWatchers.MovementLock.Current) &&
                 TestValue(MusicId, memoryWatchers.MusicId.Current) &&
+                TestValue(RoomNumberAlt, memoryWatchers.RoomNumberAlt.Current) &&
                 TestValue(CutsceneAlt, memoryWatchers.CutsceneAlt.Current) &&
                 TestValue(AirshipDestinations, memoryWatchers.AirshipDestinations.Current) &&
                 TestValue(AuronOverdrives, memoryWatchers.AuronOverdrives.Current) &&

--- a/FFXCutsceneRemover/Components/GameState.cs
+++ b/FFXCutsceneRemover/Components/GameState.cs
@@ -76,7 +76,6 @@ namespace FFXCutsceneRemover
                 TestValue(CutsceneAlt, memoryWatchers.CutsceneAlt.Current) &&
                 TestValue(AirshipDestinations, memoryWatchers.AirshipDestinations.Current) &&
                 TestValue(AuronOverdrives, memoryWatchers.AuronOverdrives.Current) &&
-                TestValue(PartyMembers, memoryWatchers.PartyMembers.Current) &&
                 TestValue(EnableWakka, memoryWatchers.EnableWakka.Current) &&
                 TestValue(EnableRikku, memoryWatchers.EnableRikku.Current) &&
                 TestValue(Sandragoras, memoryWatchers.Sandragoras.Current) &&

--- a/FFXCutsceneRemover/Components/MemoryWatchers.cs
+++ b/FFXCutsceneRemover/Components/MemoryWatchers.cs
@@ -82,6 +82,7 @@ namespace FFXCutsceneRemover
 
         public MemoryWatcher<byte> ViaPurificoPlatform;
         public MemoryWatcher<byte> CalmLandsFlag;
+        public MemoryWatcher<byte> GagazetCaveFlag;
 
         MemoryWatchers() { }
 
@@ -168,6 +169,7 @@ namespace FFXCutsceneRemover
 
             ViaPurificoPlatform = GetMemoryWatcher<byte>(MemoryLocations.ViaPurificoPlatform);
             CalmLandsFlag = GetMemoryWatcher<byte>(MemoryLocations.CalmLandsFlag);
+            GagazetCaveFlag = GetMemoryWatcher<byte>(MemoryLocations.GagazetCaveFlag);
 
             Watchers.Clear();
             Watchers.AddRange(new List<MemoryWatcher>() { 
@@ -220,7 +222,8 @@ namespace FFXCutsceneRemover
                     RikkuOutfit,
                     MacalaniaFlag,
                     ViaPurificoPlatform,
-                    CalmLandsFlag
+                    CalmLandsFlag,
+                    GagazetCaveFlag
             });
         }
 

--- a/FFXCutsceneRemover/Components/MemoryWatchers.cs
+++ b/FFXCutsceneRemover/Components/MemoryWatchers.cs
@@ -28,7 +28,6 @@ namespace FFXCutsceneRemover
         public MemoryWatcher<short> Input;
         public MemoryWatcher<byte> Menu;
         public MemoryWatcher<short> Intro;
-        public MemoryWatcher<short> FangirlsOrKidsSkip;
         public MemoryWatcher<sbyte> State;
         public MemoryWatcher<float> XCoordinate;
         public MemoryWatcher<float> YCoordinate;
@@ -41,11 +40,14 @@ namespace FFXCutsceneRemover
         public MemoryWatcher<short> CutsceneAlt;
         public MemoryWatcher<short> AirshipDestinations;
         public MemoryWatcher<short> AuronOverdrives;
-        public MemoryWatcher<byte> PartyMembers;
-        public MemoryWatcher<byte> Sandragoras;
+        
+        // Deep Pointers
         public MemoryWatcher<int> HpEnemyA;
         public MemoryWatcher<byte> GuadoCount;
 
+        // Party Configuration
+        public MemoryWatcher<byte> Formation;
+        public MemoryWatcher<byte> RikkuName;
         public MemoryWatcher<byte> EnableTidus;
         public MemoryWatcher<byte> EnableYuna;
         public MemoryWatcher<byte> EnableAuron;
@@ -56,30 +58,53 @@ namespace FFXCutsceneRemover
         public MemoryWatcher<byte> EnableSeymour;
         public MemoryWatcher<byte> EnableValefor;
 
+        // HP/MP
+        public MemoryWatcher<int> TidusHP;
+        public MemoryWatcher<short> TidusMP;
+        public MemoryWatcher<int> TidusMaxHP;
+        public MemoryWatcher<short> TidusMaxMP;
+        public MemoryWatcher<int> YunaHP;
+        public MemoryWatcher<short> YunaMP;
+        public MemoryWatcher<int> YunaMaxHP;
+        public MemoryWatcher<short> YunaMaxMP;
+        public MemoryWatcher<int> AuronHP;
+        public MemoryWatcher<short> AuronMP;
+        public MemoryWatcher<int> AuronMaxHP;
+        public MemoryWatcher<short> AuronMaxMP;
+        public MemoryWatcher<int> WakkaHP;
+        public MemoryWatcher<short> WakkaMP;
+        public MemoryWatcher<int> WakkaMaxHP;
+        public MemoryWatcher<short> WakkaMaxMP;
+        public MemoryWatcher<int> KimahriHP;
+        public MemoryWatcher<short> KimahriMP;
+        public MemoryWatcher<int> KimahriMaxHP;
+        public MemoryWatcher<short> KimahriMaxMP;
+        public MemoryWatcher<int> LuluHP;
+        public MemoryWatcher<short> LuluMP;
+        public MemoryWatcher<int> LuluMaxHP;
+        public MemoryWatcher<short> LuluMaxMP;
+        public MemoryWatcher<int> RikkuHP;
+        public MemoryWatcher<short> RikkuMP;
+        public MemoryWatcher<int> RikkuMaxHP;
+        public MemoryWatcher<short> RikkuMaxMP;
+
+        // Special Flags
+        public MemoryWatcher<short> FangirlsOrKidsSkip;
         public MemoryWatcher<byte> BaajFlag1;
-
         public MemoryWatcher<byte> BesaidFlag1;
-
         public MemoryWatcher<byte> SSWinnoFlag1;
         public MemoryWatcher<byte> SSWinnoFlag2;
-
         public MemoryWatcher<byte> LucaFlag;
         public MemoryWatcher<byte> LucaFlag2;
-
         public MemoryWatcher<byte> MiihenFlag1;
         public MemoryWatcher<byte> MiihenFlag2;
         public MemoryWatcher<byte> MiihenFlag3;
         public MemoryWatcher<byte> MiihenFlag4;
-
         public MemoryWatcher<byte> MoonflowFlag;
         public MemoryWatcher<byte> MoonflowFlag2;
         public MemoryWatcher<byte> RikkuOutfit;
-
         public MemoryWatcher<byte> MacalaniaFlag;
-
-        public MemoryWatcher<byte> Formation;
-        public MemoryWatcher<byte> RikkuName;
-
+        public MemoryWatcher<byte> Sandragoras;
         public MemoryWatcher<byte> ViaPurificoPlatform;
         public MemoryWatcher<byte> CalmLandsFlag;
         public MemoryWatcher<byte> GagazetCaveFlag;
@@ -115,7 +140,6 @@ namespace FFXCutsceneRemover
             Input = GetMemoryWatcher<short>(MemoryLocations.Input);
             Menu = GetMemoryWatcher<byte>(MemoryLocations.Menu);
             Intro = GetMemoryWatcher<short>(MemoryLocations.Intro);
-            FangirlsOrKidsSkip = GetMemoryWatcher<short>(MemoryLocations.FangirlsOrKidsSkip);
             State = GetMemoryWatcher<sbyte>(MemoryLocations.State);
             XCoordinate = GetMemoryWatcher<float>(MemoryLocations.XCoordinate);
             YCoordinate = GetMemoryWatcher<float>(MemoryLocations.YCoordinate);
@@ -128,11 +152,14 @@ namespace FFXCutsceneRemover
             CutsceneAlt = GetMemoryWatcher<short>(MemoryLocations.CutsceneAlt);
             AirshipDestinations = GetMemoryWatcher<short>(MemoryLocations.AirshipDestinations);
             AuronOverdrives = GetMemoryWatcher<short>(MemoryLocations.AuronOverdrives);
-            PartyMembers = GetMemoryWatcher<byte>(MemoryLocations.PartyMembers);
-            Sandragoras = GetMemoryWatcher<byte>(MemoryLocations.Sandragoras);
+
+            // Deep Pointers
             HpEnemyA = GetMemoryWatcher<int>(MemoryLocations.HpEnemyA);
             GuadoCount = GetMemoryWatcher<byte>(MemoryLocations.GuadoCount);
 
+            // Party Configuration
+            Formation = GetMemoryWatcher<byte>(MemoryLocations.Formation);
+            RikkuName = GetMemoryWatcher<byte>(MemoryLocations.RikkuName);
             EnableTidus = GetMemoryWatcher<byte>(MemoryLocations.EnableTidus);
             EnableYuna = GetMemoryWatcher<byte>(MemoryLocations.EnableYuna);
             EnableAuron = GetMemoryWatcher<byte>(MemoryLocations.EnableAuron);
@@ -143,34 +170,57 @@ namespace FFXCutsceneRemover
             EnableSeymour = GetMemoryWatcher<byte>(MemoryLocations.EnableSeymour);
             EnableValefor = GetMemoryWatcher<byte>(MemoryLocations.EnableValefor);
 
+            // HP/MP
+            TidusHP = GetMemoryWatcher<int>(MemoryLocations.TidusHP);
+            TidusMP = GetMemoryWatcher<short>(MemoryLocations.TidusMP);
+            TidusMaxHP = GetMemoryWatcher<int>(MemoryLocations.TidusMaxHP);
+            TidusMaxMP = GetMemoryWatcher<short>(MemoryLocations.TidusMaxMP);
+            YunaHP = GetMemoryWatcher<int>(MemoryLocations.YunaHP);
+            YunaMP = GetMemoryWatcher<short>(MemoryLocations.YunaMP);
+            YunaMaxHP = GetMemoryWatcher<int>(MemoryLocations.YunaMaxHP);
+            YunaMaxMP = GetMemoryWatcher<short>(MemoryLocations.YunaMaxMP);
+            AuronHP = GetMemoryWatcher<int>(MemoryLocations.AuronHP);
+            AuronMP = GetMemoryWatcher<short>(MemoryLocations.AuronMP);
+            AuronMaxHP = GetMemoryWatcher<int>(MemoryLocations.AuronMaxHP);
+            AuronMaxMP = GetMemoryWatcher<short>(MemoryLocations.AuronMaxMP);
+            WakkaHP = GetMemoryWatcher<int>(MemoryLocations.WakkaHP);
+            WakkaMP = GetMemoryWatcher<short>(MemoryLocations.WakkaMP);
+            WakkaMaxHP = GetMemoryWatcher<int>(MemoryLocations.WakkaMaxHP);
+            WakkaMaxMP = GetMemoryWatcher<short>(MemoryLocations.WakkaMaxMP);
+            KimahriHP = GetMemoryWatcher<int>(MemoryLocations.KimahriHP);
+            KimahriMP = GetMemoryWatcher<short>(MemoryLocations.KimahriMP);
+            KimahriMaxHP = GetMemoryWatcher<int>(MemoryLocations.KimahriMaxHP);
+            KimahriMaxMP = GetMemoryWatcher<short>(MemoryLocations.KimahriMaxMP);
+            LuluHP = GetMemoryWatcher<int>(MemoryLocations.LuluHP);
+            LuluMP = GetMemoryWatcher<short>(MemoryLocations.LuluMP);
+            LuluMaxHP = GetMemoryWatcher<int>(MemoryLocations.LuluMaxHP);
+            LuluMaxMP = GetMemoryWatcher<short>(MemoryLocations.LuluMaxMP);
+            RikkuHP = GetMemoryWatcher<int>(MemoryLocations.RikkuHP);
+            RikkuMP = GetMemoryWatcher<short>(MemoryLocations.RikkuMP);
+            RikkuMaxHP = GetMemoryWatcher<int>(MemoryLocations.RikkuMaxHP);
+            RikkuMaxMP = GetMemoryWatcher<short>(MemoryLocations.RikkuMaxMP);
+
+            // Special Flags
+            FangirlsOrKidsSkip = GetMemoryWatcher<short>(MemoryLocations.FangirlsOrKidsSkip);
             BaajFlag1 = GetMemoryWatcher<byte>(MemoryLocations.BaajFlag1);
-
             BesaidFlag1 = GetMemoryWatcher<byte>(MemoryLocations.BesaidFlag1);
-
             SSWinnoFlag1 = GetMemoryWatcher<byte>(MemoryLocations.SSWinnoFlag1);
             SSWinnoFlag2 = GetMemoryWatcher<byte>(MemoryLocations.SSWinnoFlag2);
-
             LucaFlag = GetMemoryWatcher<byte>(MemoryLocations.LucaFlag);
             LucaFlag2 = GetMemoryWatcher<byte>(MemoryLocations.LucaFlag2);
-
             MiihenFlag1 = GetMemoryWatcher<byte>(MemoryLocations.MiihenFlag1);
             MiihenFlag2 = GetMemoryWatcher<byte>(MemoryLocations.MiihenFlag2);
             MiihenFlag3 = GetMemoryWatcher<byte>(MemoryLocations.MiihenFlag3);
             MiihenFlag4 = GetMemoryWatcher<byte>(MemoryLocations.MiihenFlag4);
-
             MoonflowFlag = GetMemoryWatcher<byte>(MemoryLocations.MoonflowFlag);
             MoonflowFlag2 = GetMemoryWatcher<byte>(MemoryLocations.MoonflowFlag2);
             RikkuOutfit = GetMemoryWatcher<byte>(MemoryLocations.RikkuOutfit);
-
             MacalaniaFlag = GetMemoryWatcher<byte>(MemoryLocations.MacalaniaFlag);
-
-            Formation = GetMemoryWatcher<byte>(MemoryLocations.Formation);
-            RikkuName = GetMemoryWatcher<byte>(MemoryLocations.RikkuName);
-
+            Sandragoras = GetMemoryWatcher<byte>(MemoryLocations.Sandragoras);
             ViaPurificoPlatform = GetMemoryWatcher<byte>(MemoryLocations.ViaPurificoPlatform);
             CalmLandsFlag = GetMemoryWatcher<byte>(MemoryLocations.CalmLandsFlag);
             GagazetCaveFlag = GetMemoryWatcher<byte>(MemoryLocations.GagazetCaveFlag);
-
+            
             Watchers.Clear();
             Watchers.AddRange(new List<MemoryWatcher>() { 
                     RoomNumber,
@@ -194,7 +244,6 @@ namespace FFXCutsceneRemover
                     RoomNumberAlt,
                     AirshipDestinations,
                     AuronOverdrives,
-                    PartyMembers,
                     Sandragoras,
                     HpEnemyA,
                     GuadoCount,
@@ -207,6 +256,13 @@ namespace FFXCutsceneRemover
                     EnableRikku,
                     EnableSeymour,
                     EnableValefor,
+                    TidusHP, TidusMP, TidusMaxHP, TidusMaxMP,
+                    YunaHP, YunaMP, YunaMaxHP, YunaMaxMP,
+                    AuronHP, AuronMP, AuronMaxHP, AuronMaxMP,
+                    WakkaHP, WakkaMP, WakkaMaxHP, WakkaMaxMP,
+                    KimahriHP, KimahriMP, KimahriMaxHP, KimahriMaxMP,
+                    LuluHP, LuluMP, LuluMaxHP, LuluMaxMP,
+                    RikkuHP, RikkuMP, RikkuMaxHP, RikkuMaxMP,
                     BaajFlag1,
                     BesaidFlag1,
                     SSWinnoFlag1,

--- a/FFXCutsceneRemover/Components/MemoryWatchers.cs
+++ b/FFXCutsceneRemover/Components/MemoryWatchers.cs
@@ -37,6 +37,7 @@ namespace FFXCutsceneRemover
         public MemoryWatcher<byte> EncounterStatus;
         public MemoryWatcher<byte> MovementLock;
         public MemoryWatcher<byte> MusicId;
+        public MemoryWatcher<byte> RoomNumberAlt;
         public MemoryWatcher<short> CutsceneAlt;
         public MemoryWatcher<short> AirshipDestinations;
         public MemoryWatcher<short> AuronOverdrives;
@@ -122,6 +123,7 @@ namespace FFXCutsceneRemover
             EncounterStatus = GetMemoryWatcher<byte>(MemoryLocations.EncounterStatus);
             MovementLock = GetMemoryWatcher<byte>(MemoryLocations.MovementLock);
             MusicId = GetMemoryWatcher<byte>(MemoryLocations.MusicId);
+            RoomNumberAlt = GetMemoryWatcher<byte>(MemoryLocations.RoomNumberAlt);
             CutsceneAlt = GetMemoryWatcher<short>(MemoryLocations.CutsceneAlt);
             AirshipDestinations = GetMemoryWatcher<short>(MemoryLocations.AirshipDestinations);
             AuronOverdrives = GetMemoryWatcher<short>(MemoryLocations.AuronOverdrives);
@@ -187,6 +189,7 @@ namespace FFXCutsceneRemover
                     MovementLock,
                     MusicId,
                     CutsceneAlt,
+                    RoomNumberAlt,
                     AirshipDestinations,
                     AuronOverdrives,
                     PartyMembers,

--- a/FFXCutsceneRemover/Components/PreviousGameState.cs
+++ b/FFXCutsceneRemover/Components/PreviousGameState.cs
@@ -54,7 +54,6 @@ namespace FFXCutsceneRemover
                 TestValue(CutsceneAlt, memoryWatchers.CutsceneAlt.Old) &&
                 TestValue(AirshipDestinations, memoryWatchers.AirshipDestinations.Old) &&
                 TestValue(AuronOverdrives, memoryWatchers.AuronOverdrives.Old) &&
-                TestValue(PartyMembers, memoryWatchers.PartyMembers.Old) &&
                 TestValue(Sandragoras, memoryWatchers.Sandragoras.Old) &&
                 TestValue(HpEnemyA, memoryWatchers.HpEnemyA.Old) &&
                 TestValue(GuadoCount, memoryWatchers.GuadoCount.Old);

--- a/FFXCutsceneRemover/Components/Transition.cs
+++ b/FFXCutsceneRemover/Components/Transition.cs
@@ -31,6 +31,7 @@ namespace FFXCutsceneRemover
         public byte? EncounterStatus = null;
         public byte? MovementLock = null;
         public byte? MusicId = null;
+        public short? RoomNumberAlt = null;
         public short? CutsceneAlt = null;
         public short? AirshipDestinations = null;
         public short? AuronOverdrives = null;
@@ -94,6 +95,7 @@ namespace FFXCutsceneRemover
             WriteValue(memoryWatchers.EncounterStatus, EncounterStatus);
             WriteValue(memoryWatchers.MovementLock, MovementLock);
             WriteValue(memoryWatchers.MusicId, MusicId);
+            WriteValue(memoryWatchers.RoomNumberAlt, RoomNumberAlt);
             WriteValue(memoryWatchers.CutsceneAlt, CutsceneAlt);
             WriteValue(memoryWatchers.AirshipDestinations, AirshipDestinations);
             WriteValue(memoryWatchers.AuronOverdrives, AuronOverdrives);

--- a/FFXCutsceneRemover/Components/Transition.cs
+++ b/FFXCutsceneRemover/Components/Transition.cs
@@ -74,6 +74,7 @@ namespace FFXCutsceneRemover
 
         public byte? ViaPurificoPlatform = null;
         public byte? CalmLandsFlag = null;
+        public byte? GagazetCaveFlag = null;
 
         public void Execute()
         {
@@ -131,6 +132,7 @@ namespace FFXCutsceneRemover
             WriteBytes(memoryWatchers.RikkuName, RikkuName);
             WriteValue(memoryWatchers.ViaPurificoPlatform, ViaPurificoPlatform);
             WriteValue(memoryWatchers.CalmLandsFlag, CalmLandsFlag);
+            WriteValue(memoryWatchers.GagazetCaveFlag, GagazetCaveFlag);
 
             if (ForceLoad)
             {

--- a/FFXCutsceneRemover/Components/Transition.cs
+++ b/FFXCutsceneRemover/Components/Transition.cs
@@ -1,6 +1,7 @@
 ﻿using FFX_Cutscene_Remover.ComponentUtil;
 using System;
 using System.Diagnostics;
+using FFXCutsceneRemover.Resources;
 
 namespace FFXCutsceneRemover
 {
@@ -12,6 +13,7 @@ namespace FFXCutsceneRemover
 
         private Process process;
         public bool ForceLoad = true;
+        public bool FullHeal = false;
         public string Description = null;
 
         /* Only add members here for memory addresses that we want to write the value to.
@@ -100,7 +102,6 @@ namespace FFXCutsceneRemover
             WriteValue(memoryWatchers.CutsceneAlt, CutsceneAlt);
             WriteValue(memoryWatchers.AirshipDestinations, AirshipDestinations);
             WriteValue(memoryWatchers.AuronOverdrives, AuronOverdrives);
-            WriteValue(memoryWatchers.PartyMembers, PartyMembers);
             WriteValue(memoryWatchers.Sandragoras, Sandragoras);
             WriteValue(memoryWatchers.HpEnemyA, HpEnemyA);
             WriteValue(memoryWatchers.GuadoCount, GuadoCount);
@@ -138,6 +139,11 @@ namespace FFXCutsceneRemover
             {
                 ForceGameLoad();
             }
+
+            if (FullHeal)
+            {
+                FullPartyHeal();
+            }
         }
 
         private void WriteValue<T>(MemoryWatcher watcher, T? value) where T : struct
@@ -174,6 +180,25 @@ namespace FFXCutsceneRemover
         private void ForceGameLoad()
         {
             WriteValue<byte>(memoryWatchers.ForceLoad, 1);
+        }
+
+        private void FullPartyHeal()
+        {
+            WriteValue<int>(memoryWatchers.TidusHP, memoryWatchers.TidusMaxHP.Current);
+            WriteValue<int>(memoryWatchers.YunaHP, memoryWatchers.YunaMaxHP.Current);
+            WriteValue<int>(memoryWatchers.AuronHP, memoryWatchers.AuronMaxHP.Current);
+            WriteValue<int>(memoryWatchers.KimahriHP, memoryWatchers.KimahriMaxHP.Current);
+            WriteValue<int>(memoryWatchers.WakkaHP, memoryWatchers.WakkaMaxHP.Current);
+            WriteValue<int>(memoryWatchers.LuluHP, memoryWatchers.LuluMaxHP.Current);
+            WriteValue<int>(memoryWatchers.RikkuHP, memoryWatchers.RikkuMaxHP.Current);
+            
+            WriteValue<short>(memoryWatchers.TidusMP, memoryWatchers.TidusMaxMP.Current);
+            WriteValue<short>(memoryWatchers.YunaMP, memoryWatchers.YunaMaxMP.Current);
+            WriteValue<short>(memoryWatchers.AuronMP, memoryWatchers.AuronMaxMP.Current);
+            WriteValue<short>(memoryWatchers.WakkaMP, memoryWatchers.WakkaMaxMP.Current);
+            WriteValue<short>(memoryWatchers.KimahriMP, memoryWatchers.KimahriMaxMP.Current);
+            WriteValue<short>(memoryWatchers.LuluMP, memoryWatchers.LuluMaxMP.Current);
+            WriteValue<short>(memoryWatchers.RikkuMP, memoryWatchers.RikkuMaxMP.Current);
         }
     }
 }

--- a/FFXCutsceneRemover/Resources/MemoryLocationNames.cs
+++ b/FFXCutsceneRemover/Resources/MemoryLocationNames.cs
@@ -12,7 +12,6 @@
         public static string Input = "Input";
         public static string Menu = "Menu";
         public static string Intro = "Intro";
-        public static string FangirlsOrKidsSkip = "FangirlsOrKidsSkip";
         public static string State = "State";
         public static string XCoordinate = "XCoordinate";
         public static string YCoordinate = "YCoordinate";
@@ -25,11 +24,14 @@
         public static string CutsceneAlt = "CutsceneAlt";
         public static string AirshipDestinations = "AirshipDestinations";
         public static string AuronOverdrives = "AuronOverdrives";
-        public static string PartyMembers = "PartyMembers";
-        public static string Sandragoras = "Sandragoras";
+
+        // Deep Pointers
         public static string HpEnemyA = "HpEnemyA";
         public static string GuadoCount = "GuadoCount";
-
+        
+        // Party Configuration
+        public static string Formation = "Formation";
+        public static string RikkuName = "RikkuName";
         public static string EnableTidus = "EnableTidus";
         public static string EnableYuna = "EnableYuna";
         public static string EnableAuron = "EnableAuron";
@@ -39,33 +41,27 @@
         public static string EnableRikku = "EnableRikku";
         public static string EnableSeymour = "EnableSeymour";
         public static string EnableValefor = "EnableValefor";
-
+        
+        // Special Flags
+        public static string FangirlsOrKidsSkip = "FangirlsOrKidsSkip";
         public static string BaajFlag1 = "BaajFlag1";
-
         public static string BesaidFlag1 = "BesaidFlag1";
-
         public static string SSWinnoFlag1 = "SSWinnoFlag1";
         public static string SSWinnoFlag2 = "SSWinnoFlag2";
-
         public static string LucaFlag = "LucaFlag";
         public static string LucaFlag2 = "LucaFlag2";
-
         public static string MiihenFlag1 = "MiihenFlag1";
         public static string MiihenFlag2 = "MiihenFlag2";
         public static string MiihenFlag3 = "MiihenFlag3";
         public static string MiihenFlag4 = "MiihenFlag4";
-
         public static string MoonflowFlag = "MoonflowFlag";
         public static string MoonflowFlag2 = "MoonflowFlag2";
         public static string RikkuOutfit = "RikkuOutfit";
-
         public static string MacalaniaFlag = "MacalaniaFlag";
-
-        public static string Formation = "Formation";
-        public static string RikkuName = "RikkuName";
-
+        public static string Sandragoras = "Sandragoras";
         public static string ViaPurificoPlatform = "ViaPurificoPlatform";
         public static string CalmLandsFlag = "CalmLandsFlag";
         public static string GagazetCaveFlag = "GagazetCaveFlag";
+
     }
 }

--- a/FFXCutsceneRemover/Resources/MemoryLocationNames.cs
+++ b/FFXCutsceneRemover/Resources/MemoryLocationNames.cs
@@ -21,6 +21,7 @@
         public static string EncounterStatus = "EncounterStatus";
         public static string MovementLock = "MovementLock";
         public static string MusicId = "MusicId";
+        public static string RoomNumberAlt = "RoomNumberAlt";
         public static string CutsceneAlt = "CutsceneAlt";
         public static string AirshipDestinations = "AirshipDestinations";
         public static string AuronOverdrives = "AuronOverdrives";

--- a/FFXCutsceneRemover/Resources/MemoryLocationNames.cs
+++ b/FFXCutsceneRemover/Resources/MemoryLocationNames.cs
@@ -66,5 +66,6 @@
 
         public static string ViaPurificoPlatform = "ViaPurificoPlatform";
         public static string CalmLandsFlag = "CalmLandsFlag";
+        public static string GagazetCaveFlag = "GagazetCaveFlag";
     }
 }

--- a/FFXCutsceneRemover/Resources/MemoryLocations.cs
+++ b/FFXCutsceneRemover/Resources/MemoryLocations.cs
@@ -72,7 +72,7 @@
 
         public static MemoryLocationData ViaPurificoPlatform = new MemoryLocationData(MemoryLocationNames.ViaPurificoPlatform, 0xD2CC89);
         public static MemoryLocationData CalmLandsFlag = new MemoryLocationData(MemoryLocationNames.CalmLandsFlag, 0xD2CD09);
-        
+        public static MemoryLocationData GagazetCaveFlag = new MemoryLocationData(MemoryLocationNames.GagazetCaveFlag, 0xD2CD56);
         
     }
 

--- a/FFXCutsceneRemover/Resources/MemoryLocations.cs
+++ b/FFXCutsceneRemover/Resources/MemoryLocations.cs
@@ -16,7 +16,6 @@
         public static MemoryLocationData Input = new MemoryLocationData(MemoryLocationNames.Input, 0x8CB170);
         public static MemoryLocationData Menu = new MemoryLocationData(MemoryLocationNames.Menu, 0xF407E4);
         public static MemoryLocationData Intro = new MemoryLocationData(MemoryLocationNames.Intro, 0x922D64);
-        public static MemoryLocationData FangirlsOrKidsSkip = new MemoryLocationData(MemoryLocationNames.FangirlsOrKidsSkip, 0xD2CE7C);
         public static MemoryLocationData State = new MemoryLocationData(MemoryLocationNames.State, 0xD381AC);
         public static MemoryLocationData XCoordinate = new MemoryLocationData(MemoryLocationNames.XCoordinate, 0xF25D80);
         public static MemoryLocationData YCoordinate = new MemoryLocationData(MemoryLocationNames.YCoordinate, 0xF25D78);
@@ -29,13 +28,14 @@
         public static MemoryLocationData CutsceneAlt = new MemoryLocationData(MemoryLocationNames.CutsceneAlt, 0xD27C88);
         public static MemoryLocationData AirshipDestinations = new MemoryLocationData(MemoryLocationNames.AirshipDestinations, 0xD2D710);
         public static MemoryLocationData AuronOverdrives = new MemoryLocationData(MemoryLocationNames.AuronOverdrives, 0xD307FC);
-        public static MemoryLocationData PartyMembers = new MemoryLocationData(MemoryLocationNames.PartyMembers, 0xD307E8);
-        public static MemoryLocationData Sandragoras = new MemoryLocationData(MemoryLocationNames.Sandragoras, 0xD2CD4E);
-        
+
         // Deep Pointers
         public static MemoryLocationData HpEnemyA = new MemoryLocationData(MemoryLocationNames.HpEnemyA, 0xD34460, 0x5D0);
         public static MemoryLocationData GuadoCount = new MemoryLocationData(MemoryLocationNames.GuadoCount, 0x00F2FF14, 0x120);
 
+        // Party Configuration
+        public static MemoryLocationData Formation = new MemoryLocationData(MemoryLocationNames.Formation, 0xD307E8);
+        public static MemoryLocationData RikkuName = new MemoryLocationData(MemoryLocationNames.RikkuName, 0xD32E54);
         public static MemoryLocationData EnableTidus = new MemoryLocationData(MemoryLocationNames.EnableTidus, 0xD32088);
         public static MemoryLocationData EnableYuna = new MemoryLocationData(MemoryLocationNames.EnableYuna, 0xD3211C);
         public static MemoryLocationData EnableAuron = new MemoryLocationData(MemoryLocationNames.EnableAuron, 0xD321B0);
@@ -45,31 +45,60 @@
         public static MemoryLocationData EnableRikku = new MemoryLocationData(MemoryLocationNames.EnableRikku, 0xD32400);
         public static MemoryLocationData EnableSeymour = new MemoryLocationData(MemoryLocationNames.EnableSeymour, 0xD32494);
         public static MemoryLocationData EnableValefor = new MemoryLocationData(MemoryLocationNames.EnableValefor, 0xD32528);
+        
+        // HP/MP TODO: Find a better method for full party restore to clean this up
+        public static MemoryLocationData TidusHP = new MemoryLocationData("TidusHP", 0xD32078);
+        public static MemoryLocationData TidusMaxHP = new MemoryLocationData("TidusMaxHP", 0xD32080);
+        public static MemoryLocationData TidusMP = new MemoryLocationData("TidusMP", 0xD3207C);
+        public static MemoryLocationData TidusMaxMP = new MemoryLocationData("TidusMaxMP", 0xD32084);
+        
+        public static MemoryLocationData YunaHP = new MemoryLocationData("YunaHP", 0xD3210C);
+        public static MemoryLocationData YunaMaxHP = new MemoryLocationData("YunaMaxHP", 0xD32114);
+        public static MemoryLocationData YunaMP = new MemoryLocationData("YunaMP", 0xD32110);
+        public static MemoryLocationData YunaMaxMP = new MemoryLocationData("YunaMaxMP", 0xD32118);
+        
+        public static MemoryLocationData AuronHP = new MemoryLocationData("AuronHP", 0xD321A0);
+        public static MemoryLocationData AuronMaxHP = new MemoryLocationData("AuronMaxHP", 0xD321A8);
+        public static MemoryLocationData AuronMP = new MemoryLocationData("AuronMP", 0xD321A4);
+        public static MemoryLocationData AuronMaxMP = new MemoryLocationData("AuronMaxMP", 0xD321AC);
+        
+        public static MemoryLocationData KimahriHP = new MemoryLocationData("KimahriHP", 0xD32234);
+        public static MemoryLocationData KimahriMaxHP = new MemoryLocationData("KimahriMaxHP", 0xD3223C);
+        public static MemoryLocationData KimahriMP = new MemoryLocationData("KimahriMP", 0xD32238);
+        public static MemoryLocationData KimahriMaxMP = new MemoryLocationData("KimahriMaxMP", 0xD32240);
+        
+        public static MemoryLocationData WakkaHP = new MemoryLocationData("WakkaHP", 0xD322C8);
+        public static MemoryLocationData WakkaMaxHP = new MemoryLocationData("WakkaMaxHP", 0xD322D0);
+        public static MemoryLocationData WakkaMP = new MemoryLocationData("WakkaMP", 0xD322CC);
+        public static MemoryLocationData WakkaMaxMP = new MemoryLocationData("WakkaMaxMP", 0xD322D4);
+        
+        public static MemoryLocationData LuluHP = new MemoryLocationData("LuluHP", 0xD3235C);
+        public static MemoryLocationData LuluMaxHP = new MemoryLocationData("LuluMaxHP", 0xD32364);
+        public static MemoryLocationData LuluMP = new MemoryLocationData("LuluMP", 0xD32360);
+        public static MemoryLocationData LuluMaxMP = new MemoryLocationData("LuluMaxMP", 0xD32368);
+        
+        public static MemoryLocationData RikkuHP = new MemoryLocationData("RikkuHP", 0xD323F0);
+        public static MemoryLocationData RikkuMaxHP = new MemoryLocationData("RikkuMaxHP", 0xD323F8);
+        public static MemoryLocationData RikkuMP = new MemoryLocationData("RikkuMP", 0xD323F4);
+        public static MemoryLocationData RikkuMaxMP = new MemoryLocationData("RikkuMaxMP", 0xD323FC);
 
+        // Special Flags
+        public static MemoryLocationData FangirlsOrKidsSkip = new MemoryLocationData(MemoryLocationNames.FangirlsOrKidsSkip, 0xD2CE7C);
         public static MemoryLocationData BaajFlag1 = new MemoryLocationData(MemoryLocationNames.BaajFlag1, 0xD2CE0C);
-
         public static MemoryLocationData BesaidFlag1 = new MemoryLocationData(MemoryLocationNames.BesaidFlag1, 0xF25AB3);
-
         public static MemoryLocationData SSWinnoFlag1 = new MemoryLocationData(MemoryLocationNames.SSWinnoFlag1, 0xD2CE7D);
         public static MemoryLocationData SSWinnoFlag2 = new MemoryLocationData(MemoryLocationNames.SSWinnoFlag2, 0xD2CE7F);
-
         public static MemoryLocationData LucaFlag = new MemoryLocationData(MemoryLocationNames.LucaFlag, 0xD2CDE5);
         public static MemoryLocationData LucaFlag2 = new MemoryLocationData(MemoryLocationNames.LucaFlag2, 0xD2CDE4);
-
         public static MemoryLocationData MiihenFlag1 = new MemoryLocationData(MemoryLocationNames.MiihenFlag1, 0xD2CCFE);
         public static MemoryLocationData MiihenFlag2 = new MemoryLocationData(MemoryLocationNames.MiihenFlag2, 0xD2CCFF);
         public static MemoryLocationData MiihenFlag3 = new MemoryLocationData(MemoryLocationNames.MiihenFlag3, 0xD2CD00);
         public static MemoryLocationData MiihenFlag4 = new MemoryLocationData(MemoryLocationNames.MiihenFlag4, 0xD2CD04);
-
         public static MemoryLocationData MoonflowFlag = new MemoryLocationData(MemoryLocationNames.MoonflowFlag, 0xD2CC7F);
         public static MemoryLocationData MoonflowFlag2 = new MemoryLocationData(MemoryLocationNames.MoonflowFlag2, 0xD2CC83);
         public static MemoryLocationData RikkuOutfit = new MemoryLocationData(MemoryLocationNames.RikkuOutfit, 0xD2CB61);
-
         public static MemoryLocationData MacalaniaFlag = new MemoryLocationData(MemoryLocationNames.MacalaniaFlag, 0xD2CD16);
-
-        public static MemoryLocationData Formation = new MemoryLocationData(MemoryLocationNames.Formation, 0xD307E8);
-        public static MemoryLocationData RikkuName = new MemoryLocationData(MemoryLocationNames.RikkuName, 0xD32E54);
-
+        public static MemoryLocationData Sandragoras = new MemoryLocationData(MemoryLocationNames.Sandragoras, 0xD2CD4E);
         public static MemoryLocationData ViaPurificoPlatform = new MemoryLocationData(MemoryLocationNames.ViaPurificoPlatform, 0xD2CC89);
         public static MemoryLocationData CalmLandsFlag = new MemoryLocationData(MemoryLocationNames.CalmLandsFlag, 0xD2CD09);
         public static MemoryLocationData GagazetCaveFlag = new MemoryLocationData(MemoryLocationNames.GagazetCaveFlag, 0xD2CD56);

--- a/FFXCutsceneRemover/Resources/MemoryLocations.cs
+++ b/FFXCutsceneRemover/Resources/MemoryLocations.cs
@@ -25,6 +25,7 @@
         public static MemoryLocationData EncounterStatus = new MemoryLocationData(MemoryLocationNames.EncounterStatus, 0xF25D70);
         public static MemoryLocationData MovementLock = new MemoryLocationData(MemoryLocationNames.MovementLock, 0xF25B63);
         public static MemoryLocationData MusicId = new MemoryLocationData(MemoryLocationNames.MusicId, 0xF2FF1C);
+        public static MemoryLocationData RoomNumberAlt = new MemoryLocationData(MemoryLocationNames.RoomNumberAlt, 0xD2Ca92);
         public static MemoryLocationData CutsceneAlt = new MemoryLocationData(MemoryLocationNames.CutsceneAlt, 0xD27C88);
         public static MemoryLocationData AirshipDestinations = new MemoryLocationData(MemoryLocationNames.AirshipDestinations, 0xD2D710);
         public static MemoryLocationData AuronOverdrives = new MemoryLocationData(MemoryLocationNames.AuronOverdrives, 0xD307FC);

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -306,7 +306,7 @@ namespace FFXCutsceneRemover.Resources
 		    // START OF CALM LANDS & GAGAZET
 		    { new GameState { RoomNumber = 206, Storyline = 2300, CutsceneAlt = 3712}, new Transition { RoomNumber = 177, Storyline = 2385, SpawnPoint = 1, Description = "Lake Scene"} },
 		    { new GameState { RoomNumber = 223, Storyline = 2385}, new Transition { Storyline = 2400, CalmLandsFlag = 36, ForceLoad = false, Description = "Calm Lands Intro + Gorge flag"} },
-		    { new GameState { RoomNumber = 279, Storyline = 2420, MovementLock = 48, XCoordinate = 265.3771973f }, new Transition { RoomNumber = 259, Storyline = 2510, SpawnPoint = 0, Description = "Yuna reflects"} },
+		    { new GameState { RoomNumber = 279, Storyline = 2420, MovementLock = 48, XCoordinate = 265.3771973f }, new Transition { RoomNumber = 259, Storyline = 2510, RoomNumberAlt = 266, SpawnPoint = 0, Description = "Yuna reflects"} },
 	        { new GameState { RoomNumber = 259, Storyline = 2510, CutsceneAlt = 70}, new Transition { Storyline = 2530, SpawnPoint = 1, Description = "Ronso Singing"} },
 		    // TODO: Add back in the flashback
 		    // TODO: Auron talks to Yuna at the end of the cave

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -56,7 +56,7 @@ namespace FFXCutsceneRemover.Resources
             // START OF BESAID
             { new GameState { RoomNumber = 70, Storyline = 111 }, new Transition { Storyline = 113, SpawnPoint = 0, Description = "Tidus wakes up in the sea"} }, //Bug(Minor): Aurochs don't spawn on the beach
                                             // Wakka pushes Tidus ( Wakka joins the party)
-            { new GameState { RoomNumber = 41, Storyline = 119, CutsceneAlt = 1353 }, new Transition { RoomNumber = 67, Storyline = 124, Description = "Wakka asks Tidus to join his team"} },
+            { new GameState { RoomNumber = 41, Storyline = 119, CutsceneAlt = 73 }, new Transition { RoomNumber = 67, Storyline = 124, Description = "Wakka asks Tidus to join his team"} },
             { new GameState { RoomNumber = 67, Storyline = 124 }, new Transition { RoomNumber = 69, Storyline = 130, SpawnPoint = 0, Description = "Wakka explains his life story"} },
             { new GameState { RoomNumber = 133, Storyline = 130, }, new Transition { RoomNumber = 17, Storyline = 134, SpawnPoint = 3, Description = "Tidus arrives at Besaid Village" } },
             { new GameState { RoomNumber = 84, Storyline = 134 }, new Transition { RoomNumber = 84, Storyline = 136, SpawnPoint = 0, Description = "Tidus enters the temple"} },

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -95,8 +95,8 @@ namespace FFXCutsceneRemover.Resources
             // END OF SS LIKI
             // START OF KILIKA
             { new GameState { RoomNumber = 43, Storyline = 292 }, new Transition { RoomNumber = 43, Storyline = 294, SpawnPoint = 0, Description = "Undocking in Kilika" } },
-            { new GameState { RoomNumber = 53, Storyline = 294, State = 0 }, new Transition { RoomNumber = 152, Storyline = 304, Description = "Sending" } },
-            { new GameState { RoomNumber = 152, Storyline = 300 }, new Transition { RoomNumber = 152, Storyline = 302, SpawnPoint = 0, Description = "Tidus wakes up" } },
+            { new GameState { RoomNumber = 53, Storyline = 294, State = 0 }, new Transition { RoomNumber = 152, Storyline = 300, Description = "Sending" } },
+            { new GameState { RoomNumber = 152, Storyline = 300 }, new Transition { RoomNumber = 152, Storyline = 302, SpawnPoint = 0, FullHeal = true, Description = "Tidus wakes up" } },
             { new GameState { RoomNumber = 16, Storyline = 304, State = 1 }, new Transition { Storyline = 308, SpawnPoint = 2, Description = "Tidus speaks to Wakka"} },
             { new GameState { RoomNumber = 18, Storyline = 308 }, new Transition { RoomNumber = 18, Storyline = 312, SpawnPoint = 0, Description = "Camera pan + Yuna wants a new guardian" } },
             { new GameState { RoomNumber = 65, Storyline = 315 }, new Transition { RoomNumber = 65, Storyline = 322, SpawnPoint = 0, Description = "Race up the stairs"} },

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -69,8 +69,7 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { RoomNumber = 42, Storyline = 170 }, new Transition { RoomNumber = 42, Storyline = 172, SpawnPoint = 0, Description = "The gang leave the cloister of trials"} },
                                             // Valefor summon
                                             // Tidus monologue after naming
-            { new GameState { RoomNumber = 100, Storyline = 180 }, new Transition { RoomNumber = 68, Storyline = 184, Description = "Tidus joins the Aurochs"} },
-            { new GameState { RoomNumber = 68, Storyline = 184 }, new Transition { RoomNumber = 252, Storyline = 190, Description = "Tidus sleeping"} },
+	        { new GameState { RoomNumber = 68, Storyline = 184 }, new Transition { RoomNumber = 252, Storyline = 190, Description = "Tidus sleeping"} },
             { new GameState { RoomNumber = 252, Storyline = 190, State = 1 }, new Transition { RoomNumber = 60, Storyline = 196, Description = "Tidus has a dream about Yuna, Tidus wakes up + FMV" } },
                                             // Tidus wakes up again (Party healed at this point)
             //{ new GameState { RoomNumber = 17, Storyline = 200 }, new Transition { RoomNumber = 69, Storyline = 210, SpawnPoint = 515, Description = "Yuna says goodbye to Besaid" } }, // Bug: Need to Enable + Equip Brotherhood, Lulu, Yuna, lots of things!
@@ -330,6 +329,7 @@ namespace FFXCutsceneRemover.Resources
 
         public static readonly Dictionary<IGameState, Transition> PostBossBattleTransitions = new Dictionary<IGameState, Transition>()
         {
+	        { new GameState { RoomNumber = 83, Storyline = 172, State = 1 }, new Transition { RoomNumber = 68, Storyline = 184, Description = "Tidus joins the Aurochs"} },
             { new GameState { HpEnemyA = 6000, Storyline = 502 }, new Transition { RoomNumber = 121, Storyline = 508, Description = "Oblitzerator"} },
             { new GameState { HpEnemyA = 6000, Storyline = 865 }, new Transition { RoomNumber = 254, Storyline = 882, EnableTidus = 17, EnableKimahri = 17, EnableLulu = 17, EnableWakka = 17, Description = "Sinspawn Gui 2"} }, // Bug: minor, formation gets set back to whatever it was in Gui 1, would need to store what it was!
             { new GameState { HpEnemyA = 12000, Storyline = 1420 }, new Transition { RoomNumber = 221, Storyline = 1480, SpawnPoint = 2, Description = "Spherimorph", AuronOverdrives = 11569} },
@@ -338,7 +338,7 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { HpEnemyA = 12000, Storyline = 1704 }, new Transition { RoomNumber = 129, Storyline = 1715, SpawnPoint = 0, Description = "Bikanel Zu",
 	            Formation = new byte[]{ 0x0, 0x2, 0x5, 0x4, 0xFF, 0xFF, 0xFF }, EnableWakka = 17} },
             { new GameState { HpEnemyA = 9000, Storyline = 1885 }, new Transition { RoomNumber = 280, Storyline = 1940, SpawnPoint = 4, Description = "Home Chimera"} },
-            { new GameState { HpEnemyA = 70000, Storyline = 2530 }, new Transition { RoomNumber = 285, Storyline = 2585, SpawnPoint = 2, Description = "Seymour Flux"} },
+            { new GameState { HpEnemyA = 70000, Storyline = 2530 }, new Transition { RoomNumber = 285, Storyline = 2585, SpawnPoint = 2, GagazetCaveFlag = 177, Description = "Seymour Flux"} },
             { new GameState { HpEnemyA = 40000, Storyline = 2585 }, new Transition { RoomNumber = 311, Storyline = 2680, SpawnPoint = 0, Description = "Sanctuary Keeper"} },
             { new GameState { HpEnemyA = 24000, Storyline = 2815 }, new Transition { RoomNumber = 270, Storyline = 2850, SpawnPoint = 0, Description = "Yunalesca"} },
             { new GameState { HpEnemyA = 80000, Storyline = 3205 }, new  Transition { Storyline = 3250, ForceLoad = false, Description = "Seymour Omnis"} }

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -8,7 +8,9 @@ namespace FFXCutsceneRemover.Resources
         public static readonly Dictionary<IGameState, Transition> StandardTransitions = new Dictionary<IGameState, Transition>()
         {
             // SPECIAL
+#if DEBUG
             { new GameState { Input = 2304, BattleState = 10 },  new Transition { BattleState = 778, ForceLoad = false, Description = "End any battle by holding start + select"} },
+#endif
             { new GameState { RoomNumber = 348 }, new Transition { RoomNumber = 23, Description = "Skip Intro"} },
             { new GameState { RoomNumber = 349 }, new Transition { RoomNumber = 23, Description = "Skip Intro"} },
             // START OF ZANARKAND
@@ -68,8 +70,7 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { RoomNumber = 103, Storyline = 164}, new Transition { RoomNumber = 42, Storyline = 170, EnableValefor = 17, Description = "Tidus meets Lulu and Kimahri + FMV "} },
             { new GameState { RoomNumber = 42, Storyline = 170 }, new Transition { RoomNumber = 42, Storyline = 172, SpawnPoint = 0, Description = "The gang leave the cloister of trials"} },
                                             // Valefor summon
-                                            // Tidus monologue after naming
-	        { new GameState { RoomNumber = 68, Storyline = 184 }, new Transition { RoomNumber = 252, Storyline = 190, Description = "Tidus sleeping"} },
+			{ new GameState { RoomNumber = 68, Storyline = 184 }, new Transition { RoomNumber = 252, Storyline = 190, Description = "Tidus sleeping"} },
             { new GameState { RoomNumber = 252, Storyline = 190, State = 1 }, new Transition { RoomNumber = 60, Storyline = 196, Description = "Tidus has a dream about Yuna, Tidus wakes up + FMV" } },
                                             // Tidus wakes up again (Party healed at this point)
             //{ new GameState { RoomNumber = 17, Storyline = 200 }, new Transition { RoomNumber = 69, Storyline = 210, SpawnPoint = 515, Description = "Yuna says goodbye to Besaid" } }, // Bug: Need to Enable + Equip Brotherhood, Lulu, Yuna, lots of things!
@@ -206,7 +207,7 @@ namespace FFXCutsceneRemover.Resources
             //{ new GameState { RoomNumber = 90, Storyline = 998, State = 0 }, new Transition { RoomNumber = 90, Storyline = 1000, SpawnPoint = 0, Description = "Yuna enters the chamber"} }, : Bug: Spawned out of the cutscene
                                             // Yuna exits the chamber (name Ixion)
             { new GameState { RoomNumber = 82, Storyline = 1005 }, new Transition { RoomNumber = 82, Storyline = 1010, SpawnPoint = 4, Description = "Tidus wakes up"} },
-            //{ new GameState { RoomNumber = 161, Storyline = 1010 }, new Transition { RoomNumber = 82, Storyline = 1010, SpawnPoint = 4, Description = "Tidus wakes Yuna up"} },
+            { new GameState { RoomNumber = 161, Storyline = 1010, MovementLock = 32}, new Transition { RoomNumber = 82, Storyline = 1015, SpawnPoint = 2, Description = "Tidus wakes Yuna up"} },
             { new GameState { RoomNumber = 82, Storyline = 1015, State = 0 }, new Transition { RoomNumber = 82, Storyline = 1020, SpawnPoint = 2, Description = "Yuna has bed hair"} },
             { new GameState { RoomNumber = 76, Storyline = 1020, State = 0 }, new Transition { RoomNumber = 76, Storyline = 1025, SpawnPoint = 0, Description = "Clasko wait for me"} },
             { new GameState { RoomNumber = 93, Storyline = 1028 }, new Transition { RoomNumber = 93, Storyline = 1030, SpawnPoint = 1, Description = "Moonflow here we come"} },
@@ -253,7 +254,7 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { RoomNumber = 140, Storyline = 1300}, new Transition { RoomNumber = 140, Storyline = 1310, SpawnPoint = 0, Description = "Map + Rikku afraid + tutorial"} },
             { new GameState { RoomNumber = 140, Storyline = 1310, State = 0}, new Transition { RoomNumber = 256, Storyline = 1310, SpawnPoint = 0, Description = "Rikku freaks out"} },
             { new GameState { RoomNumber = 256, Storyline = 1310}, new Transition { RoomNumber = 263, Storyline = 1315, SpawnPoint = 0, Description = "Rikku asks to go to the agency"} },    
-            { new GameState { RoomNumber = 264, Storyline = 1320}, new Transition { RoomNumber = 263, Storyline = 1325, Description = "Tidus barges in Yuna's room + Sleep"} }, // bug: party not healed
+            { new GameState { RoomNumber = 264, Storyline = 1320}, new Transition { RoomNumber = 263, Storyline = 1325, FullHeal = true, Description = "Tidus barges in Yuna's room + Sleep"} },
             { new GameState { RoomNumber = 263, Storyline = 1335}, new Transition { RoomNumber = 256, Storyline = 1340, Description = "Leaving the agency"} },
             { new GameState { RoomNumber = 162, Storyline = 1340}, new Transition { RoomNumber = 162, Storyline = 1375, Description = "Yuna decides to marry Seymour"} },
             // END OF THUNDER PLAINS


### PR DESCRIPTION
Various fixes and improvements:

- Fix spawn at the base of Gagazet when entering after defeating Defender X
- Improved cutscene skip after Valefor using Boss loop for menu flag
- Added HP/MP restore for Thunder plains agency & Kilika-- This added a lot of memory addresses and I'm sure there is a better way to do this
- Rearranged some memory addresses since the list was getting quite long and messy
- Fixed "Wakka asks Tidus to join his team" skip
- Added cutscene skip for the last cutscene in Gagazet cave (Auron talks to Yuna about Yunalesca)