### PR TITLE
Chocobo Eater skip + fixes

### DIFF
--- a/FFXCutsceneRemover/Components/MemoryWatchers.cs
+++ b/FFXCutsceneRemover/Components/MemoryWatchers.cs
@@ -112,6 +112,7 @@ namespace FFXCutsceneRemover
         public MemoryWatcher<byte> RikkuOutfit;
         public MemoryWatcher<byte> TidusWeaponDamageBoost;
         public MemoryWatcher<byte> MacalaniaFlag;
+        public MemoryWatcher<byte> BikanelFlag;
         public MemoryWatcher<byte> Sandragoras;
         public MemoryWatcher<byte> ViaPurificoPlatform;
         public MemoryWatcher<short> CalmLandsFlag;
@@ -229,6 +230,7 @@ namespace FFXCutsceneRemover
             RikkuOutfit = GetMemoryWatcher<byte>(MemoryLocations.RikkuOutfit);
             TidusWeaponDamageBoost = GetMemoryWatcher<byte>(MemoryLocations.TidusWeaponDamageBoost);
             MacalaniaFlag = GetMemoryWatcher<byte>(MemoryLocations.MacalaniaFlag);
+            BikanelFlag = GetMemoryWatcher<byte>(MemoryLocations.BikanelFlag);
             Sandragoras = GetMemoryWatcher<byte>(MemoryLocations.Sandragoras);
             ViaPurificoPlatform = GetMemoryWatcher<byte>(MemoryLocations.ViaPurificoPlatform);
             CalmLandsFlag = GetMemoryWatcher<short>(MemoryLocations.CalmLandsFlag);
@@ -292,6 +294,7 @@ namespace FFXCutsceneRemover
                     RikkuOutfit,
                     TidusWeaponDamageBoost,
                     MacalaniaFlag,
+                    BikanelFlag,
                     ViaPurificoPlatform,
                     CalmLandsFlag,
                     GagazetCaveFlag

--- a/FFXCutsceneRemover/Components/SinspawnGuiTransition.cs
+++ b/FFXCutsceneRemover/Components/SinspawnGuiTransition.cs
@@ -1,0 +1,28 @@
+﻿using FFX_Cutscene_Remover.ComponentUtil;
+using System.Diagnostics;
+
+namespace FFXCutsceneRemover
+{
+    /* Special transition for the Sinspawn Gui fight. Formation is stored in memory after the Gui 1 fight
+     * and reapplied after the Gui 2 fight, so reproduced here by storing the formation statically */
+    class SinspawnGuiTransition : Transition
+    {
+        static private byte[] GuiFormation = { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0xFF };
+        public override void Execute(string defaultDescription = "")
+        {
+            base.Execute(); // Execute the cutscene transition first (AreaID + Cutscene etc)
+
+            if (Storyline == 865)
+            {
+                // Finished Sinspawn Gui 1, so remember the formation
+                Process process = memoryWatchers.Process;
+                GuiFormation = process.ReadBytes(memoryWatchers.Formation.Address, 7);
+            }
+            else if (Storyline == 882)
+            {
+                // Finished Sinspawn Gui 2, so reapply the formation
+                WriteBytes(base.memoryWatchers.Formation, GuiFormation);
+            }
+        }
+    }
+}

--- a/FFXCutsceneRemover/Components/Transition.cs
+++ b/FFXCutsceneRemover/Components/Transition.cs
@@ -74,6 +74,7 @@ namespace FFXCutsceneRemover
         public byte? TidusWeaponDamageBoost = null;
 
         public byte? MacalaniaFlag = null;
+        public byte? BikanelFlag = null;
 
         public byte[] Formation = null;
         public byte[] RikkuName = null;
@@ -139,6 +140,7 @@ namespace FFXCutsceneRemover
             WriteValue(memoryWatchers.RikkuOutfit, RikkuOutfit);
             WriteValue(memoryWatchers.TidusWeaponDamageBoost, TidusWeaponDamageBoost);
             WriteValue(memoryWatchers.MacalaniaFlag, MacalaniaFlag);
+            WriteValue(memoryWatchers.BikanelFlag, BikanelFlag);
             WriteBytes(memoryWatchers.Formation, Formation);
             WriteBytes(memoryWatchers.RikkuName, RikkuName);
             WriteValue(memoryWatchers.ViaPurificoPlatform, ViaPurificoPlatform);

--- a/FFXCutsceneRemover/Components/Transition.cs
+++ b/FFXCutsceneRemover/Components/Transition.cs
@@ -171,7 +171,7 @@ namespace FFXCutsceneRemover
             }
         }
 
-        private void WriteBytes(MemoryWatcher watcher, byte[] bytes)
+        protected void WriteBytes(MemoryWatcher watcher, byte[] bytes)
         {
             if (bytes != null)
             {

--- a/FFXCutsceneRemover/Resources/MemoryLocationNames.cs
+++ b/FFXCutsceneRemover/Resources/MemoryLocationNames.cs
@@ -59,6 +59,7 @@
         public static string RikkuOutfit = "RikkuOutfit";
         public static string TidusWeaponDamageBoost = "TidusWeaponDamageBoost";
         public static string MacalaniaFlag = "MacalaniaFlag";
+        public static string BikanelFlag = "BikanelFlag";
         public static string Sandragoras = "Sandragoras";
         public static string ViaPurificoPlatform = "ViaPurificoPlatform";
         public static string CalmLandsFlag = "CalmLandsFlag";

--- a/FFXCutsceneRemover/Resources/MemoryLocations.cs
+++ b/FFXCutsceneRemover/Resources/MemoryLocations.cs
@@ -106,6 +106,7 @@
         public static MemoryLocationData RikkuOutfit = new MemoryLocationData(MemoryLocationNames.RikkuOutfit, 0xD2CB61);
         public static MemoryLocationData TidusWeaponDamageBoost = new MemoryLocationData(MemoryLocationNames.TidusWeaponDamageBoost, 0x1F11240);
         public static MemoryLocationData MacalaniaFlag = new MemoryLocationData(MemoryLocationNames.MacalaniaFlag, 0xD2CD16);
+        public static MemoryLocationData BikanelFlag = new MemoryLocationData(MemoryLocationNames.BikanelFlag, 0xD2CD4B);
         public static MemoryLocationData Sandragoras = new MemoryLocationData(MemoryLocationNames.Sandragoras, 0xD2CD4E);
         public static MemoryLocationData ViaPurificoPlatform = new MemoryLocationData(MemoryLocationNames.ViaPurificoPlatform, 0xD2CC89);
         public static MemoryLocationData CalmLandsFlag = new MemoryLocationData(MemoryLocationNames.CalmLandsFlag, 0xD2CD09);

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -271,7 +271,7 @@ namespace FFXCutsceneRemover.Resources
 		    } },
 		    { new GameState { RoomNumber = 136, Storyline = 1718, EnableRikku = 0, State = 1 }, new Transition
 			{
-				Storyline = 1720, SpawnPoint = 3, EnableRikku = 17, Description = "Wakka Glare",
+				Storyline = 1720, SpawnPoint = 3, EnableRikku = 17, BikanelFlag = 32, Description = "Wakka Glare",
 				Formation = new byte[]{ 0x0, 0x2, 0x5, 0x4, 0x3, 0x6, 0xFF }
 			} },
 		    { new GameState { Storyline = 1940, EncounterStatus = 89 }, new Transition { EncounterStatus = 88, ForceLoad = false, Description = "Disabling Encounters"} },

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -184,10 +184,10 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { RoomNumber = 119, Storyline = 825 }, new Transition { Storyline = 845, Description = "Preparing for Sin" } },
                                             // Pre-Sinspawn Gui
             { new GameState { RoomNumber = 119, Storyline = 857, BattleState = 522, CutsceneAlt = 260 }, new Transition { Storyline = 860, Description = "Post-Sinspawn Gui + FMV" } },
-            { new GameState { RoomNumber = 119, Storyline = 860 }, new Transition { RoomNumber = 247, Storyline = 865, Description = "Auron Look out + FMV " } },
+            { new GameState { RoomNumber = 119, Storyline = 860 }, new SinspawnGuiTransition { RoomNumber = 247, Storyline = 865, Description = "Auron Look out + FMV " } },
                                             // Pre-Sinspawn Gui 2
                                             // Post-Sinspawn Gui 2
-            { new GameState { RoomNumber = 254, Storyline = 882 }, new Transition { RoomNumber = 254, Storyline = 893, EnableSeymour = 16, Formation = new byte[]{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0xFF }, Description = "Tidus wakes up + sees Gatta"} }, // Bug: It sets whatever formation you had on previously back on, we would have to store that in memory to do the same
+            { new GameState { RoomNumber = 254, Storyline = 882 }, new Transition { RoomNumber = 254, Storyline = 893, EnableSeymour = 16, Description = "Tidus wakes up + sees Gatta"} },
             { new GameState { RoomNumber = 254, Storyline = 893 }, new Transition { RoomNumber = 247, Storyline = 899, Description = "Sin FMV + Tidus chases after Sin"} },
             { new GameState { RoomNumber = 247, Storyline = 899 }, new Transition { RoomNumber = 218, Storyline = 902, Description = "Yuna tries to summon"} },
             { new GameState { RoomNumber = 218, Storyline = 902 }, new Transition { RoomNumber = 341, Storyline = 910, Description = "Tidus is swimming"} },
@@ -332,7 +332,7 @@ namespace FFXCutsceneRemover.Resources
         {
 	        { new GameState { RoomNumber = 83, Storyline = 172, State = 1 }, new Transition { RoomNumber = 68, Storyline = 184, Description = "Tidus joins the Aurochs"} },
             { new GameState { HpEnemyA = 6000, Storyline = 502 }, new Transition { RoomNumber = 121, Storyline = 508, Description = "Oblitzerator"} },
-            { new GameState { HpEnemyA = 6000, Storyline = 865 }, new Transition { RoomNumber = 254, Storyline = 882, EnableTidus = 17, EnableKimahri = 17, EnableLulu = 17, EnableWakka = 17, Description = "Sinspawn Gui 2"} }, // Bug: minor, formation gets set back to whatever it was in Gui 1, would need to store what it was!
+            { new GameState { HpEnemyA = 6000, Storyline = 865 }, new SinspawnGuiTransition { RoomNumber = 254, Storyline = 882, EnableTidus = 17, EnableKimahri = 17, EnableLulu = 17, EnableWakka = 17, Description = "Sinspawn Gui 2"} },
             { new GameState { HpEnemyA = 12000, Storyline = 1420 }, new Transition { RoomNumber = 221, Storyline = 1480, SpawnPoint = 2, Description = "Spherimorph", AuronOverdrives = 11569} },
             { new GameState { HpEnemyA = 16000, Storyline = 1485 }, new Transition { RoomNumber = 192, Storyline = 1504, SpawnPoint = 1, Description = "Crawler"} },
             { new GameState { HpEnemyA = 1200, RoomNumber = 102, Storyline = 1570 }, new Transition { RoomNumber = 54, Storyline = 1600, SpawnPoint = 0, Description = "Wendigo"} }, // HP Value is the Guard

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -183,7 +183,7 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { RoomNumber = 79, Storyline = 787 }, new Transition { RoomNumber = 79, Storyline = 825, SpawnPoint = 0, Description = "Tidus distrusts Seymour"} },
             { new GameState { RoomNumber = 119, Storyline = 825 }, new Transition { Storyline = 845, Description = "Preparing for Sin" } },
                                             // Pre-Sinspawn Gui
-            { new GameState { RoomNumber = 119, Storyline = 857, BattleState = 522, CutsceneAlt = 260 }, new Transition { Storyline = 860, Description = "Post-Sinspawn Gui + FMV" } },
+            { new GameState { RoomNumber = 119, Storyline = 857, BattleState = 522, CutsceneAlt = 1 }, new Transition { Storyline = 860, Description = "Post-Sinspawn Gui + FMV" } },
             { new GameState { RoomNumber = 119, Storyline = 860 }, new SinspawnGuiTransition { RoomNumber = 247, Storyline = 865, Description = "Auron Look out + FMV " } },
                                             // Pre-Sinspawn Gui 2
                                             // Post-Sinspawn Gui 2

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -183,7 +183,7 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { RoomNumber = 79, Storyline = 787 }, new Transition { RoomNumber = 79, Storyline = 825, SpawnPoint = 0, Description = "Tidus distrusts Seymour"} },
             { new GameState { RoomNumber = 119, Storyline = 825 }, new Transition { Storyline = 845, Description = "Preparing for Sin" } },
                                             // Pre-Sinspawn Gui
-            { new GameState { RoomNumber = 119, Storyline = 857, BattleState = 522, CutsceneAlt = 1 }, new Transition { Storyline = 860, Description = "Post-Sinspawn Gui + FMV" } },
+            { new GameState { RoomNumber = 119, Storyline = 857, CutsceneAlt = 1 }, new Transition { Storyline = 860, Description = "Post-Sinspawn Gui + FMV" } },
             { new GameState { RoomNumber = 119, Storyline = 860 }, new SinspawnGuiTransition { RoomNumber = 247, Storyline = 865, Description = "Auron Look out + FMV " } },
                                             // Pre-Sinspawn Gui 2
                                             // Post-Sinspawn Gui 2

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -174,7 +174,8 @@ namespace FFXCutsceneRemover.Resources
                                             // Meet Rin
             { new GameState { RoomNumber = 58, Storyline = 767, MiihenFlag3 = 0 }, new Transition { MiihenFlag3 = 1 , ForceLoad = false, Description = "To the chocobo corral"} },
                                             // Pre-Chocobo Eater
-                                            // Fall down the cliff (MiihenFlag = 3 after)
+            { new GameState { RoomNumber = 58, Storyline = 770, MiihenFlag3 = 3 }, new Transition { RoomNumber = 115, Storyline = 772, SpawnPoint = 515, Description = "Chocobo Eater loss - Fall down the cliff"} },
+            { new GameState { RoomNumber = 58, Storyline = 770, MiihenFlag3 = 5 }, new Transition { Storyline = 772, SpawnPoint = 2, MiihenFlag3 = 13, Description = "Chocobo Eater win - Rin thanks the party"} },
             { new GameState { RoomNumber = 116, Storyline = 772, MiihenFlag4 = 0}, new Transition { MiihenFlag4 = 4 , ForceLoad = false, Description = "Luzzu and Gatta move a cart"} },
             { new GameState { RoomNumber = 59, Storyline = 777, State = 0}, new Transition { Storyline = 787, SpawnPoint = 3, Description = "Seymour helps out"} },
             // END OF MI'IHEN


### PR DESCRIPTION
**Besaid**
- Fix to Brotherhood cutscene skip where Map wasn't added to the items. Now iterates through the list of items and finds the first empty slot to add to.

**Mi'ihen Highroad**
- New skip added post Chocobo Eater fight. Whether you win or lose, the cutscene after the fight will be skipped.

**Mushroom Rock Road**
- Attempt at fixing the skip after the Sinspawn Gui 1 fight. Hopefully does, although not 100% convinced it's consistent.
- Formation fix after Sinspawn Gui 2. Now remembers the formation from the Gui 1 fight, and applies it after the Gui 2 fight.

**Bikanel**
- Rikku machina tutorial has been readded back in