### PR TITLE
Various fixes

### DIFF
--- a/FFXCutsceneRemover/Components/CutsceneRemover.cs
+++ b/FFXCutsceneRemover/Components/CutsceneRemover.cs
@@ -125,10 +125,12 @@ namespace FFXCutsceneRemover
                      * Make sure to call ExecuteTransition() instead of calling the Transition.Execute() method directly.
                      */
                     // Soft reset by holding L1 R1 L2 R2 + Start - Disabled in battle because game crashes
+#if DEBUG
                     if (new GameState { Input = 2063 }.CheckState() && MemoryWatchers.BattleState.Current != 10)
                     {
                         ExecuteTransition(new Transition { RoomNumber = 23, BattleState = 778, Description = "Soft reset by holding L1 R1 L2 R2 + Start" });
                     }
+#endif
                     
                     // Custom Check #1 - Sandragoras
                     if (new GameState { RoomNumber = 138, Storyline = 1720, State = 1}.CheckState() && MemoryWatchers.Sandragoras.Current >= 4)

--- a/FFXCutsceneRemover/Components/CutsceneRemover.cs
+++ b/FFXCutsceneRemover/Components/CutsceneRemover.cs
@@ -194,6 +194,15 @@ namespace FFXCutsceneRemover
                             }
                         }
                     }
+                    
+                    // Custom Check #5 - Baaj Menu patch
+                    // This check disables the menu for the two screens before Geosgaeno. Opening the menu here hardlocks the game
+                    if (new GameState {RoomNumber = 48, MenuLock = 152}.CheckState() ||
+                        new GameState {RoomNumber = 49, MenuLock = 152}.CheckState())
+                    {
+                        Console.WriteLine("Disabling menu temporarily");
+                        Game.WriteValue(MemoryWatchers.MenuLock.Address, 136);
+                    }
 
                     // Sleep for a bit so we don't destroy CPUs
                     Thread.Sleep(LoopSleepMillis);

--- a/FFXCutsceneRemover/Components/CutsceneRemover.cs
+++ b/FFXCutsceneRemover/Components/CutsceneRemover.cs
@@ -200,7 +200,6 @@ namespace FFXCutsceneRemover
                     if (new GameState {RoomNumber = 48, MenuLock = 152}.CheckState() ||
                         new GameState {RoomNumber = 49, MenuLock = 152}.CheckState())
                     {
-                        Console.WriteLine("Disabling menu temporarily");
                         Game.WriteValue(MemoryWatchers.MenuLock.Address, 136);
                     }
 

--- a/FFXCutsceneRemover/Components/GameState.cs
+++ b/FFXCutsceneRemover/Components/GameState.cs
@@ -17,6 +17,7 @@ namespace FFXCutsceneRemover
         public int? BattleState = null;
         public short? Input = null;
         public byte? Menu = null;
+        public byte? MenuLock = null;
         public byte? FangirlsOrKidsSkip = null;
         public short? Intro = null;
         public sbyte? State = null;
@@ -62,6 +63,7 @@ namespace FFXCutsceneRemover
                 TestValue(BattleState, memoryWatchers.BattleState.Current) &&
                 TestValue(Input, memoryWatchers.Input.Current) &&
                 TestValue(Menu, memoryWatchers.Menu.Current) &&
+                TestValue(MenuLock, memoryWatchers.MenuLock.Current) &&
                 TestValue(FangirlsOrKidsSkip, memoryWatchers.FangirlsOrKidsSkip.Current) &&
                 TestValue(Intro, memoryWatchers.Intro.Current) &&
                 TestValue(State, memoryWatchers.State.Current) &&

--- a/FFXCutsceneRemover/Components/MemoryWatchers.cs
+++ b/FFXCutsceneRemover/Components/MemoryWatchers.cs
@@ -27,6 +27,7 @@ namespace FFXCutsceneRemover
         public MemoryWatcher<int> BattleState;
         public MemoryWatcher<short> Input;
         public MemoryWatcher<byte> Menu;
+        public MemoryWatcher<byte> MenuLock;
         public MemoryWatcher<short> Intro;
         public MemoryWatcher<sbyte> State;
         public MemoryWatcher<float> XCoordinate;
@@ -148,6 +149,7 @@ namespace FFXCutsceneRemover
             BattleState = GetMemoryWatcher<int>(MemoryLocations.BattleState);
             Input = GetMemoryWatcher<short>(MemoryLocations.Input);
             Menu = GetMemoryWatcher<byte>(MemoryLocations.Menu);
+            MenuLock = GetMemoryWatcher<byte>(MemoryLocations.MenuLock);
             Intro = GetMemoryWatcher<short>(MemoryLocations.Intro);
             State = GetMemoryWatcher<sbyte>(MemoryLocations.State);
             XCoordinate = GetMemoryWatcher<float>(MemoryLocations.XCoordinate);
@@ -245,6 +247,7 @@ namespace FFXCutsceneRemover
                     BattleState,
                     Input,
                     Menu,
+                    MenuLock,
                     Intro,
                     FangirlsOrKidsSkip,
                     State,

--- a/FFXCutsceneRemover/Components/PreviousGameState.cs
+++ b/FFXCutsceneRemover/Components/PreviousGameState.cs
@@ -17,6 +17,7 @@ namespace FFXCutsceneRemover
         public int? BattleState = null;
         public short? Input = null;
         public byte? Menu = null;
+        public short? MenuLock = null;
         public short? Intro = null;
         public sbyte? State = null;
         public float? XCoordinate = null;
@@ -42,6 +43,7 @@ namespace FFXCutsceneRemover
                 TestValue(BattleState, memoryWatchers.BattleState.Old) &&
                 TestValue(Input, memoryWatchers.Input.Old) &&
                 TestValue(Menu, memoryWatchers.Menu.Old) &&
+                TestValue(MenuLock, memoryWatchers.MenuLock.Old) &&
                 TestValue(Intro, memoryWatchers.Intro.Old) &&
                 TestValue(State, memoryWatchers.State.Old) &&
                 TestValue(XCoordinate, memoryWatchers.XCoordinate.Old) &&

--- a/FFXCutsceneRemover/Components/Transition.cs
+++ b/FFXCutsceneRemover/Components/Transition.cs
@@ -26,6 +26,7 @@ namespace FFXCutsceneRemover
         public short? SpawnPoint = null;
         public int? BattleState = null;
         public byte? Menu = null;
+        public byte? MenuLock = null;
         public short? Intro = null;
         public short? FangirlsOrKidsSkip = null;
         public sbyte? State = null;
@@ -98,6 +99,7 @@ namespace FFXCutsceneRemover
             WriteValue(memoryWatchers.SpawnPoint, SpawnPoint);
             WriteValue(memoryWatchers.BattleState, BattleState);
             WriteValue(memoryWatchers.Menu, Menu);
+            WriteValue(memoryWatchers.MenuLock, MenuLock);
             WriteValue(memoryWatchers.Intro, Intro);
             WriteValue(memoryWatchers.FangirlsOrKidsSkip, FangirlsOrKidsSkip);
             WriteValue(memoryWatchers.State, State);

--- a/FFXCutsceneRemover/Resources/MemoryLocationNames.cs
+++ b/FFXCutsceneRemover/Resources/MemoryLocationNames.cs
@@ -11,6 +11,7 @@
         public static string BattleState = "BattleState";
         public static string Input = "Input";
         public static string Menu = "Menu";
+        public static string MenuLock = "MenuLock";
         public static string Intro = "Intro";
         public static string State = "State";
         public static string XCoordinate = "XCoordinate";

--- a/FFXCutsceneRemover/Resources/MemoryLocations.cs
+++ b/FFXCutsceneRemover/Resources/MemoryLocations.cs
@@ -15,6 +15,7 @@
         public static MemoryLocationData BattleState = new MemoryLocationData(MemoryLocationNames.BattleState, 0xD2C9F0);
         public static MemoryLocationData Input = new MemoryLocationData(MemoryLocationNames.Input, 0x8CB170);
         public static MemoryLocationData Menu = new MemoryLocationData(MemoryLocationNames.Menu, 0xF407E4);
+        public static MemoryLocationData MenuLock = new MemoryLocationData(MemoryLocationNames.MenuLock, 0xF25B61);
         public static MemoryLocationData Intro = new MemoryLocationData(MemoryLocationNames.Intro, 0x922D64);
         public static MemoryLocationData State = new MemoryLocationData(MemoryLocationNames.State, 0xD381AC);
         public static MemoryLocationData XCoordinate = new MemoryLocationData(MemoryLocationNames.XCoordinate, 0xF25D80);

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -183,7 +183,7 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { RoomNumber = 79, Storyline = 787 }, new Transition { RoomNumber = 79, Storyline = 825, SpawnPoint = 0, Description = "Tidus distrusts Seymour"} },
             { new GameState { RoomNumber = 119, Storyline = 825 }, new Transition { Storyline = 845, Description = "Preparing for Sin" } },
                                             // Pre-Sinspawn Gui
-            { new GameState { RoomNumber = 119, Storyline = 857, CutsceneAlt = 1 }, new Transition { Storyline = 860, Description = "Post-Sinspawn Gui + FMV" } },
+            { new GameState { RoomNumber = 119, Storyline = 857, BattleState = 522, CutsceneAlt = 1 }, new Transition { Storyline = 860, Description = "Post-Sinspawn Gui + FMV" } },
             { new GameState { RoomNumber = 119, Storyline = 860 }, new SinspawnGuiTransition { RoomNumber = 247, Storyline = 865, Description = "Auron Look out + FMV " } },
                                             // Pre-Sinspawn Gui 2
                                             // Post-Sinspawn Gui 2

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -186,6 +186,7 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { RoomNumber = 119, Storyline = 860 }, new Transition { RoomNumber = 247, Storyline = 865, Description = "Auron Look out + FMV " } },
                                             // Pre-Sinspawn Gui 2
                                             // Post-Sinspawn Gui 2
+	        // TODO : Find out which skip fixes the formation issue. Formation fix is higher priority than the skip
             { new GameState { RoomNumber = 254, Storyline = 882 }, new Transition { RoomNumber = 254, Storyline = 893, EnableSeymour = 16, Formation = new byte[]{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0xFF }, Description = "Tidus wakes up + sees Gatta"} }, // Bug: It sets whatever formation you had on previously back on, we would have to store that in memory to do the same
             { new GameState { RoomNumber = 254, Storyline = 893 }, new Transition { RoomNumber = 247, Storyline = 899, Description = "Sin FMV + Tidus chases after Sin"} },
             { new GameState { RoomNumber = 247, Storyline = 899 }, new Transition { RoomNumber = 218, Storyline = 902, Description = "Yuna tries to summon"} },
@@ -231,7 +232,7 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { RoomNumber = 163, Storyline = 1096, State = 1}, new Transition { RoomNumber = 163, Storyline = 1104, SpawnPoint = 1, Description = "Tromell invites the gang in"} },           
                                             // Tromell gets Seymour
                                             // Speaking to everyone
-                                            // Seymour arrives + FMV
+	        { new GameState { RoomNumber = 141, Storyline = 1104, GuadoCount = 5 }, new Transition { RoomNumber = 163, Storyline = 1126, SpawnPoint = 1, Description = "Seymour + Zanarkand"} },
             { new GameState { RoomNumber = 197, Storyline = 1104}, new Transition { RoomNumber = 217, Storyline = 1118, Description = "Seymour proposes to Yuna"} },
             { new GameState { RoomNumber = 217, Storyline = 1118}, new Transition { RoomNumber = 163, Storyline = 1126, SpawnPoint = 1, Description = "Yuna drinks a glass of water"} },
             { new GameState { RoomNumber = 135, Storyline = 1126, State = 1}, new Transition { RoomNumber = 135, Storyline = 1132, SpawnPoint = 257, Description = "The gang discuss the proposal"} },
@@ -330,7 +331,7 @@ namespace FFXCutsceneRemover.Resources
 
         public static readonly Dictionary<IGameState, Transition> PostBossBattleTransitions = new Dictionary<IGameState, Transition>()
         {
-	        { new GameState { RoomNumber = 83, Storyline = 172, State = 1 }, new Transition { RoomNumber = 68, Storyline = 184, Description = "Tidus joins the Aurochs"} },
+	        { new GameState { RoomNumber = 83, Storyline = 172, State = 1 }, new Transition { RoomNumber = 68, Storyline = 184, Description = "Tidus joins the Aurochs"} }, // Faster Valefor naming
             { new GameState { HpEnemyA = 6000, Storyline = 502 }, new Transition { RoomNumber = 121, Storyline = 508, Description = "Oblitzerator"} },
             { new GameState { HpEnemyA = 6000, Storyline = 865 }, new Transition { RoomNumber = 254, Storyline = 882, EnableTidus = 17, EnableKimahri = 17, EnableLulu = 17, EnableWakka = 17, Description = "Sinspawn Gui 2"} }, // Bug: minor, formation gets set back to whatever it was in Gui 1, would need to store what it was!
             { new GameState { HpEnemyA = 12000, Storyline = 1420 }, new Transition { RoomNumber = 221, Storyline = 1480, SpawnPoint = 2, Description = "Spherimorph", AuronOverdrives = 11569} },

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -247,7 +247,7 @@ namespace FFXCutsceneRemover.Resources
             // END OF GUADOSALAM
             // START OF THUNDER PLAINS
             { new GameState { RoomNumber = 140, Storyline = 1300}, new Transition { RoomNumber = 140, Storyline = 1310, SpawnPoint = 0, Description = "Map + Rikku afraid + tutorial"} },
-            { new GameState { RoomNumber = 140, Storyline = 1310, State = 0}, new Transition { RoomNumber = 256, Storyline = 1310, SpawnPoint = 0, Description = "Rikku freaks out"} },
+            { new GameState { RoomNumber = 140, Storyline = 1310, CutsceneAlt = 2525}, new Transition { RoomNumber = 256, Storyline = 1310, SpawnPoint = 0, Description = "Rikku freaks out"} },
             { new GameState { RoomNumber = 256, Storyline = 1310}, new Transition { RoomNumber = 263, Storyline = 1315, SpawnPoint = 0, Description = "Rikku asks to go to the agency"} },    
             { new GameState { RoomNumber = 264, Storyline = 1320}, new Transition { RoomNumber = 263, Storyline = 1325, FullHeal = true, Description = "Tidus barges in Yuna's room + Sleep"} },
             { new GameState { RoomNumber = 263, Storyline = 1335}, new Transition { RoomNumber = 256, Storyline = 1340, Description = "Leaving the agency"} },

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -182,7 +182,7 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { RoomNumber = 79, Storyline = 787 }, new Transition { RoomNumber = 79, Storyline = 825, SpawnPoint = 0, Description = "Tidus distrusts Seymour"} },
             { new GameState { RoomNumber = 119, Storyline = 825 }, new Transition { Storyline = 845, Description = "Preparing for Sin" } },
                                             // Pre-Sinspawn Gui
-            { new GameState { RoomNumber = 119, Storyline = 857, BattleState = 522, CutsceneAlt = 260 }, new Transition { Storyline = 860, Description = "Post-Sinspawn Gui + FMV" } },
+            { new GameState { RoomNumber = 119, Storyline = 857, CutsceneAlt = 1 }, new Transition { Storyline = 860, Description = "Post-Sinspawn Gui + FMV" } },
             { new GameState { RoomNumber = 119, Storyline = 860 }, new Transition { RoomNumber = 247, Storyline = 865, Description = "Auron Look out + FMV " } },
                                             // Pre-Sinspawn Gui 2
                                             // Post-Sinspawn Gui 2

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -186,7 +186,6 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { RoomNumber = 119, Storyline = 860 }, new Transition { RoomNumber = 247, Storyline = 865, Description = "Auron Look out + FMV " } },
                                             // Pre-Sinspawn Gui 2
                                             // Post-Sinspawn Gui 2
-	        // TODO : Find out which skip fixes the formation issue. Formation fix is higher priority than the skip
             { new GameState { RoomNumber = 254, Storyline = 882 }, new Transition { RoomNumber = 254, Storyline = 893, EnableSeymour = 16, Formation = new byte[]{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0xFF }, Description = "Tidus wakes up + sees Gatta"} }, // Bug: It sets whatever formation you had on previously back on, we would have to store that in memory to do the same
             { new GameState { RoomNumber = 254, Storyline = 893 }, new Transition { RoomNumber = 247, Storyline = 899, Description = "Sin FMV + Tidus chases after Sin"} },
             { new GameState { RoomNumber = 247, Storyline = 899 }, new Transition { RoomNumber = 218, Storyline = 902, Description = "Yuna tries to summon"} },
@@ -232,7 +231,7 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { RoomNumber = 163, Storyline = 1096, State = 1}, new Transition { RoomNumber = 163, Storyline = 1104, SpawnPoint = 1, Description = "Tromell invites the gang in"} },           
                                             // Tromell gets Seymour
                                             // Speaking to everyone
-	        { new GameState { RoomNumber = 141, Storyline = 1104, GuadoCount = 5 }, new Transition { RoomNumber = 163, Storyline = 1126, SpawnPoint = 1, Description = "Seymour + Zanarkand"} },
+                                            // Seymour arrives + FMV
             { new GameState { RoomNumber = 197, Storyline = 1104}, new Transition { RoomNumber = 217, Storyline = 1118, Description = "Seymour proposes to Yuna"} },
             { new GameState { RoomNumber = 217, Storyline = 1118}, new Transition { RoomNumber = 163, Storyline = 1126, SpawnPoint = 1, Description = "Yuna drinks a glass of water"} },
             { new GameState { RoomNumber = 135, Storyline = 1126, State = 1}, new Transition { RoomNumber = 135, Storyline = 1132, SpawnPoint = 257, Description = "The gang discuss the proposal"} },
@@ -331,7 +330,7 @@ namespace FFXCutsceneRemover.Resources
 
         public static readonly Dictionary<IGameState, Transition> PostBossBattleTransitions = new Dictionary<IGameState, Transition>()
         {
-	        { new GameState { RoomNumber = 83, Storyline = 172, State = 1 }, new Transition { RoomNumber = 68, Storyline = 184, Description = "Tidus joins the Aurochs"} }, // Faster Valefor naming
+	        { new GameState { RoomNumber = 83, Storyline = 172, State = 1 }, new Transition { RoomNumber = 68, Storyline = 184, Description = "Tidus joins the Aurochs"} },
             { new GameState { HpEnemyA = 6000, Storyline = 502 }, new Transition { RoomNumber = 121, Storyline = 508, Description = "Oblitzerator"} },
             { new GameState { HpEnemyA = 6000, Storyline = 865 }, new Transition { RoomNumber = 254, Storyline = 882, EnableTidus = 17, EnableKimahri = 17, EnableLulu = 17, EnableWakka = 17, Description = "Sinspawn Gui 2"} }, // Bug: minor, formation gets set back to whatever it was in Gui 1, would need to store what it was!
             { new GameState { HpEnemyA = 12000, Storyline = 1420 }, new Transition { RoomNumber = 221, Storyline = 1480, SpawnPoint = 2, Description = "Spherimorph", AuronOverdrives = 11569} },

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -200,7 +200,7 @@ namespace FFXCutsceneRemover.Resources
             // END OF MRR
             // START OF DJOSE HIGHROAD
             { new GameState { RoomNumber = 93, Storyline = 960 }, new Transition { RoomNumber = 93, Storyline = 961, SpawnPoint = 768, Description = "Kimahri speaks"} },
-            { new GameState { RoomNumber = 93, Storyline = 961, State = 0 }, new Transition { RoomNumber = 76, Storyline = 962, SpawnPoint = 1, Description = "Tidus is eager to go to Zanarkand"} },
+            { new GameState { RoomNumber = 93, Storyline = 961, CutsceneAlt = 1678 }, new Transition { RoomNumber = 76, Storyline = 962, SpawnPoint = 1, Description = "Tidus is eager to go to Zanarkand"} },
             { new GameState { RoomNumber = 76, Storyline = 962 }, new Transition { Storyline = 970, SpawnPoint = 0, Description = "Tidus whoa"} },
             { new GameState { RoomNumber = 82, Storyline = 970 }, new Transition { Storyline = 971, SpawnPoint = 0, Description = "Arrival at Djose Temple"} },
             { new GameState { RoomNumber = 81, Storyline = 971 }, new Transition { Storyline = 985, SpawnPoint = 0, Description = "Meet Isaaru"} },


### PR DESCRIPTION
Fixes:
Thunder plains Qactuar stones causing skips to the agency
Re-loading saves at Djose causing skips to Pilgrimage Road

These issues were caused by using State as a check, which I've changed to use CutsceneAlt instead.

Also decided to disable menuing before Geosgaeno since this currently causes a type of crash/lock. This can probably be removed in the future if we improve the skip here, but this seemed like a nice bandaid solution that doesn't cause any problems.