### PR TITLE
Seymour Post Cutscene Skip Implemented

### DIFF
--- a/FFXCutsceneRemover/Components/CutsceneRemover.cs
+++ b/FFXCutsceneRemover/Components/CutsceneRemover.cs
@@ -216,7 +216,10 @@ namespace FFXCutsceneRemover
             {
                 Game.Suspend();
                 transition.Execute(defaultDescription);
-                PreviouslyExecutedTransition = transition;
+                if (!transition.Repeatable)
+                {
+                    PreviouslyExecutedTransition = transition;
+                }
                 Game.Resume();
             }
         }

--- a/FFXCutsceneRemover/Components/SeymourTransition.cs
+++ b/FFXCutsceneRemover/Components/SeymourTransition.cs
@@ -20,12 +20,22 @@ namespace FFXCutsceneRemover
                 MemoryWatcher<byte> shivaEnabled2 = new MemoryWatcher<byte>(new IntPtr(baseAddress + 0xD326E4));
                 WriteValue<byte>(shivaEnabled2, 0x11);
 
-                WriteValue<int>(base.memoryWatchers.SeymourTransition, base.memoryWatchers.SeymourTransition.Current + 0xBAF);
+                BaseCutsceneValue = base.memoryWatchers.SeymourTransition.Current;
+                BaseCutsceneValue2 = base.memoryWatchers.SeymourTransition2.Current;
+
+                Console.WriteLine(BaseCutsceneValue2);
+
+                WriteValue<int>(base.memoryWatchers.SeymourTransition, BaseCutsceneValue + 0xBAF);
             }
-            else if (base.memoryWatchers.Storyline.Current == 1540)
+            else if (base.memoryWatchers.Storyline.Current == 1540 & base.memoryWatchers.SeymourTransition2.Current > BaseCutsceneValue2)
             {
+                Storyline = 1545;
+                ForceLoad = false;
+                Description = "Post-Seymour";
+                Formation = null;
+                Console.WriteLine(BaseCutsceneValue2);
                 base.Execute(); // Execute the cutscene transition first (AreaID + Cutscene etc)
-                WriteValue<int>(base.memoryWatchers.SeymourTransition2, base.memoryWatchers.SeymourTransition2.Current + 0x1703);
+                WriteValue<int>(base.memoryWatchers.SeymourTransition2, BaseCutsceneValue2 + 0x1703);
             }
         }
     }

--- a/FFXCutsceneRemover/Components/Transition.cs
+++ b/FFXCutsceneRemover/Components/Transition.cs
@@ -47,6 +47,9 @@ namespace FFXCutsceneRemover
         public byte? GuadoCount = null;
         public int? SeymourTransition = null;
         public int? SeymourTransition2 = null;
+        public int? BaseCutsceneValue = null;
+        public int? BaseCutsceneValue2 = null;
+        public bool Repeatable = false;
 
         public byte? EnableTidus = null;
         public byte? EnableYuna = null;

--- a/FFXCutsceneRemover/Resources/Transitions.cs
+++ b/FFXCutsceneRemover/Resources/Transitions.cs
@@ -5,8 +5,13 @@ namespace FFXCutsceneRemover.Resources
     /* This class contains most of the transitions. Transitions added here are automatically evalutated in the main loop. */
     static class Transitions
     {
+        static readonly SeymourTransition SeymourTransition = new SeymourTransition { Storyline = 1540, Formation = new byte[] { 0x0, 0x1, 0x3, 0x4, 0x2, 0x6, 0x5, 0xFF }, ForceLoad = false, Description = "Pre-Seymour", Repeatable = true};
+
         public static readonly Dictionary<IGameState, Transition> StandardTransitions = new Dictionary<IGameState, Transition>()
         {
+
+
+
             // SPECIAL
 #if DEBUG
             { new GameState { Input = 2304, BattleState = 10 },  new Transition { BattleState = 778, ForceLoad = false, Description = "End any battle by holding start + select"} },
@@ -259,8 +264,8 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { RoomNumber = 241, Storyline = 1407}, new Transition { RoomNumber = 241, Storyline = 1413, MacalaniaFlag = 32, Description = "Barthello has lost Dona + Butterfly guy"} },
 		    { new GameState { RoomNumber = 221, Storyline = 1413 }, new Transition { RoomNumber = 221, Storyline = 1420, SpawnPoint = 0, Description = "Pre-Spherimorph Auron Smash"} },
 		    { new GameState { RoomNumber = 106, Storyline = 1504 }, new Transition { Storyline = 1530, Description = "Jysscal Skip"} },
-            { new GameState { RoomNumber = 80, Storyline = 1530, State = 0}, new SeymourTransition { Storyline = 1540, Formation = new byte[]{0x0, 0x1, 0x3, 0x4, 0x2, 0x6, 0x5, 0xFF}, ForceLoad = false, Description = "Pre-Seymour"} },
-            { new GameState { RoomNumber = 80, Storyline = 1540, CameraRotation = -1.736438155f }, new SeymourTransition { Storyline = 1545, ForceLoad = false, Description = "Post-Seymour"} }, // TO DO: NOT WORKING
+            { new GameState { RoomNumber = 80, Storyline = 1530, State = 0}, SeymourTransition},
+            { new GameState { RoomNumber = 80, Storyline = 1540}, SeymourTransition}, // TO DO: NOT WORKING
             { new GameState { RoomNumber = 239, Storyline = 1545 }, new Transition { Storyline = 1557, ForceLoad = false, Description = "Backflip Skip"} },
 		    { new GameState { RoomNumber = 54, Storyline = 1600, State = 0 }, new Transition { Storyline = 1607, Description = "Rikku wants to be like Yuna" } },
 		    
@@ -337,6 +342,7 @@ namespace FFXCutsceneRemover.Resources
             { new GameState { HpEnemyA = 6000, Storyline = 865 }, new SinspawnGuiTransition { RoomNumber = 254, Storyline = 882, EnableTidus = 17, EnableKimahri = 17, EnableLulu = 17, EnableWakka = 17, Description = "Sinspawn Gui 2"} },
             { new GameState { HpEnemyA = 12000, Storyline = 1420 }, new Transition { RoomNumber = 221, Storyline = 1480, SpawnPoint = 2, Description = "Spherimorph", AuronOverdrives = 11569} },
             { new GameState { HpEnemyA = 16000, Storyline = 1485 }, new Transition { RoomNumber = 192, Storyline = 1504, SpawnPoint = 1, Description = "Crawler"} },
+            { new GameState { HpEnemyA = 2000, Storyline = 1540 }, new Transition { RoomNumber = 80, ForceLoad = true, SpawnPoint = 1, Description = "Seymour"} },
             { new GameState { HpEnemyA = 1200, RoomNumber = 102, Storyline = 1570 }, new Transition { RoomNumber = 54, Storyline = 1600, SpawnPoint = 0, Description = "Wendigo"} }, // HP Value is the Guard
             { new GameState { HpEnemyA = 12000, Storyline = 1704 }, new Transition { RoomNumber = 129, Storyline = 1715, SpawnPoint = 0, Description = "Bikanel Zu",
 	            Formation = new byte[]{ 0x0, 0x2, 0x5, 0x4, 0xFF, 0xFF, 0xFF }, EnableWakka = 17} },


### PR DESCRIPTION
Transitions.cs:

- Added SeymourTransition as a static class in the  Transitions class so we can store base cutscene values and recall them later.
- Removed CameraRotation logic from GameState check as this was not working consistently for me and was failing more often than not.

Transition.cs:

- Two base cutscene value ints added to Transition to store cutscene values
- Repeatable bool added to Transition to flag whether a Transition should be repeatable

CutsceneRemover.cs:

- Added logic to only set the PreviouslyExecutedTransition if the Transition is flagged as non repeatable. i.e Transition.Repeatable == false

Seymour Transitions.cs:

- Set base cutscene values when running the pre fight skip
- Update to write value relative to the base cutscene values
- Update to only run post fight skip once the cutscene value starts to increase, i.e the post cutscene has started progressing